### PR TITLE
Load local doc no filename

### DIFF
--- a/src/helpers/downloadPdf.js
+++ b/src/helpers/downloadPdf.js
@@ -4,7 +4,7 @@ import core from 'core';
 import { isIE } from 'helpers/device';
 import actions from 'actions';
 
-export default (dispatch, documentPath = 'myDocument', filename, includeAnnotations = true, xfdfData) => {
+export default (dispatch, documentPath = 'document', filename, includeAnnotations = true, xfdfData) => {
   core.getTool('AnnotationCreateFreeHand').complete();
 
   return new Promise(resolve => {

--- a/src/helpers/loadDocument.js
+++ b/src/helpers/loadDocument.js
@@ -203,9 +203,13 @@ const getEngineType = state => {
 };
 
 const getDocumentExtension = doc => {
-  // strip out query/hash parameters
-  doc = doc.split('?')[0].split('#')[0];
-  return doc.slice(doc.lastIndexOf('.') + 1).toLowerCase();
+  let extension;
+  if (doc) {
+    // strip out query/hash parameters
+    extension = doc.split('?')[0].split('#')[0];
+    extension = extension.slice(extension.lastIndexOf('.') + 1).toLowerCase();
+  }
+  return extension;
 };
 
 const getDocName = state => {


### PR DESCRIPTION
If there is file name or path specified then the document won't be able to be loaded. This just makes sure that an error isn't thrown when trying to get the extension.
Also made the default download name a bit nicer, document vs myDocument.