### PR TITLE
[update] Fires events when the visibility of an element changes

### DIFF
--- a/src/redux/actions/exposedActions.js
+++ b/src/redux/actions/exposedActions.js
@@ -1,5 +1,5 @@
 import isDataElementPanel from 'helpers/isDataElementPanel';
-
+import { fireEvent } from 'helpers/loadDocument';
 // viewer
 export const enableAllElements = () => ({ type: 'ENABLE_ALL_ELEMENTS', payload: {} });
 export const openElement = dataElement => (dispatch, getState) => {
@@ -15,6 +15,8 @@ export const openElement = dataElement => (dispatch, getState) => {
   } else {
     dispatch({ type: 'OPEN_ELEMENT', payload: { dataElement } });
   }
+
+  fireEvent('visibilityChanged', { element: dataElement, isVisible: true });
 };
 export const openElements = dataElements => dispatch => {
   dataElements.forEach(dataElement => {
@@ -33,6 +35,8 @@ export const closeElement = dataElement => (dispatch, getState) => {
   } else if (state.viewer.openElements[dataElement]) {
     dispatch({ type: 'CLOSE_ELEMENT', payload: { dataElement } });
   }
+
+    fireEvent('visibilityChanged', { element: dataElement, isVisible: false });
 };
 export const closeElements = dataElements => dispatch => {
   dataElements.forEach(dataElement => {

--- a/src/redux/actions/exposedActions.js
+++ b/src/redux/actions/exposedActions.js
@@ -22,6 +22,10 @@ export const openElement = dataElement => (dispatch, getState) => {
   } else {
     dispatch({ type: 'OPEN_ELEMENT', payload: { dataElement } });
     fireEvent('visibilityChanged', { element: dataElement, isVisible: true });
+
+    if (dataElement === 'leftPanel'  && !state.viewer.openElements['leftPanel']) {
+      fireEvent('visibilityChanged', { element: state.viewer.activeLeftPanel, isVisible: true });
+    }
   }
 };
 export const openElements = dataElements => dispatch => {
@@ -45,6 +49,10 @@ export const closeElement = dataElement => (dispatch, getState) => {
   } else {
     dispatch({ type: 'CLOSE_ELEMENT', payload: { dataElement } });
     fireEvent('visibilityChanged', { element: dataElement, isVisible: false });
+
+    if (dataElement === 'leftPanel'  && state.viewer.openElements['leftPanel']) {
+      fireEvent('visibilityChanged', { element: state.viewer.activeLeftPanel, isVisible: false });
+    }
   }
 };
 export const closeElements = dataElements => dispatch => {

--- a/src/redux/actions/exposedActions.js
+++ b/src/redux/actions/exposedActions.js
@@ -1,5 +1,6 @@
 import isDataElementPanel from 'helpers/isDataElementPanel';
 import { fireEvent } from 'helpers/loadDocument';
+
 // viewer
 export const enableAllElements = () => ({ type: 'ENABLE_ALL_ELEMENTS', payload: {} });
 export const openElement = dataElement => (dispatch, getState) => {
@@ -36,7 +37,7 @@ export const closeElement = dataElement => (dispatch, getState) => {
     dispatch({ type: 'CLOSE_ELEMENT', payload: { dataElement } });
   }
 
-    fireEvent('visibilityChanged', { element: dataElement, isVisible: false });
+  fireEvent('visibilityChanged', { element: dataElement, isVisible: false });
 };
 export const closeElements = dataElements => dispatch => {
   dataElements.forEach(dataElement => {

--- a/src/redux/actions/exposedActions.js
+++ b/src/redux/actions/exposedActions.js
@@ -18,7 +18,7 @@ export const openElement = dataElement => (dispatch, getState) => {
       dispatch({ type: 'OPEN_ELEMENT', payload: { dataElement: 'leftPanel' } });
       fireEvent('visibilityChanged', { element: 'leftPanel', isVisible: true });
     }
-    dispatch({ type: 'SET_ACTIVE_LEFT_PANEL', payload: { dataElement } });
+    dispatch(setActiveLeftPanel(dataElement));
   } else {
     dispatch({ type: 'OPEN_ELEMENT', payload: { dataElement } });
     fireEvent('visibilityChanged', { element: dataElement, isVisible: true });
@@ -71,7 +71,12 @@ export const setActiveLeftPanel = dataElement => (dispatch, getState) => {
   const state = getState();
 
   if (isDataElementPanel(dataElement, state)) {
-    dispatch({ type: 'SET_ACTIVE_LEFT_PANEL', payload: { dataElement } });
+    if (state.viewer.activeLeftPanel !== dataElement) {
+      dispatch({ type: 'CLOSE_ELEMENT', payload: { dataElement: state.viewer.activeLeftPanel } });
+      fireEvent('visibilityChanged', { element: state.viewer.activeLeftPanel, isVisible: false });
+      dispatch({ type: 'SET_ACTIVE_LEFT_PANEL', payload: { dataElement } });
+      fireEvent('visibilityChanged', { element: dataElement, isVisible: true });
+    }
   } else {
     const panelDataElements = [
       ...state.viewer.customPanels.map(({ panel }) => panel.dataElement),


### PR DESCRIPTION
The details of the event include the element itself and the new visibility of that element.

This brings back an event present in the legacy ui for reacting to UI changes (i.e. opening and closing the sidebar)

Issue was reported in the google group: https://groups.google.com/forum/#!topic/pdfnet-webviewer/wt20LMXOSpU