### PR TITLE
[update] Allows for custom annotation date format

### DIFF
--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -3,6 +3,7 @@ import closeDocument from './closeDocument';
 import downloadPdf from './downloadPdf';
 import getAnnotationUser from './getAnnotationUser';
 import setAnnotationUser from './setAnnotationUser';
+import setNoteDateFormat from './setNoteDateFormat';
 import getZoomLevel from './getZoomLevel';
 import setZoomLevel from './setZoomLevel';
 import isReadOnly from './isReadOnly';
@@ -67,6 +68,7 @@ export default {
   closeDocument,
   downloadPdf,
   getAnnotationUser,
+  setNoteDateFormat,
   setAnnotationUser,
   getZoomLevel,
   setZoomLevel,

--- a/src/apis/setNoteDateFormat.js
+++ b/src/apis/setNoteDateFormat.js
@@ -1,0 +1,5 @@
+import actions from 'actions';
+
+export default store => noteDateFormat => {
+  store.dispatch(actions.setNoteDateFormat(noteDateFormat));
+};

--- a/src/components/NoteReply/NoteReply.js
+++ b/src/components/NoteReply/NoteReply.js
@@ -48,7 +48,7 @@ class NoteReply extends React.PureComponent {
         {renderAuthorName(reply)}
         <span className="spacer"></span>
         <span className="time">
-          {' ' + dayjs(reply.DateCreated).format(noteDateFormat || 'MMM D, h:mma')}
+          {' ' + dayjs(reply.DateCreated).format(noteDateFormat)}
         </span>
         <NotePopup 
           annotation={reply} 

--- a/src/components/NoteReply/NoteReply.js
+++ b/src/components/NoteReply/NoteReply.js
@@ -6,15 +6,18 @@ import NoteContents from 'components/NoteContents';
 import NotePopup from 'components/NotePopup';
 
 import core from 'core';
+import selectors from 'selectors';
 
 import './NoteReply.scss';
+import connect from 'react-redux/es/connect/connect';
 
 class NoteReply extends React.PureComponent {
   static propTypes = {
     reply: PropTypes.object.isRequired,
     searchInput: PropTypes.string,
     renderAuthorName: PropTypes.func.isRequired,
-    renderContents: PropTypes.func.isRequired
+    renderContents: PropTypes.func.isRequired,
+    noteDateFormat: PropTypes.string
   }
 
   constructor(props) {
@@ -38,14 +41,14 @@ class NoteReply extends React.PureComponent {
   }
 
   renderHeader = () => {
-    const { reply, renderAuthorName } = this.props;
+    const { reply, renderAuthorName, noteDateFormat } = this.props;
 
     return (
       <div className="title">
         {renderAuthorName(reply)}
         <span className="spacer"></span>
         <span className="time">
-          {' ' + dayjs(reply.DateCreated).format('MMM D, h:mma')}
+          {' ' + dayjs(reply.DateCreated).format(noteDateFormat || 'MMM D, h:mma')}
         </span>
         <NotePopup 
           annotation={reply} 
@@ -76,4 +79,8 @@ class NoteReply extends React.PureComponent {
   }
 }
 
-export default NoteReply;
+const mapStateToProps = state => ({
+  noteDateFormat: selectors.getNoteDateFormat(state)
+});
+
+export default connect(mapStateToProps)(NoteReply);

--- a/src/components/NoteRoot/NoteRoot.js
+++ b/src/components/NoteRoot/NoteRoot.js
@@ -27,7 +27,8 @@ class NoteRoot extends React.Component {
     sortNotesBy: PropTypes.string.isRequired,
     openEditing: PropTypes.func.isRequired,
     closeEditing: PropTypes.func.isRequired,
-    numberOfReplies: PropTypes.number.isRequired
+    numberOfReplies: PropTypes.number.isRequired,
+    noteDateFormat: PropTypes.string
   }
 
   constructor(props) { 
@@ -55,7 +56,7 @@ class NoteRoot extends React.Component {
   }
 
   renderHeader = () => {
-    const { annotation, isNoteExpanded, sortNotesBy, openEditing, renderAuthorName, numberOfReplies } = this.props;
+    const { annotation, isNoteExpanded, sortNotesBy, openEditing, renderAuthorName, numberOfReplies, noteDateFormat } = this.props;
     const type = getAnnotationType(annotation);
     const icon = getAnnotationIcon(type);
     const color = annotationColorToCss(annotation[getAnnotationColor(type)]);
@@ -74,7 +75,7 @@ class NoteRoot extends React.Component {
         }
         <div className="time">
           {(sortNotesBy !== 'time' || isNoteExpanded) &&
-            dayjs(annotation.DateCreated || new Date()).format('MMM D, h:mma')
+            dayjs(annotation.DateCreated || new Date()).format(noteDateFormat || 'MMM D, h:mma')
           }
           {numberOfReplies > 0 &&
             ` (${numberOfReplies})`
@@ -109,7 +110,8 @@ class NoteRoot extends React.Component {
 }
 
 const mapStateToProps = state => ({
-  sortNotesBy: selectors.getSortNotesBy(state)
+  sortNotesBy: selectors.getSortNotesBy(state),
+  noteDateFormat: selectors.getNoteDateFormat(state)
 });
 
 export default connect(mapStateToProps)(NoteRoot);

--- a/src/components/NoteRoot/NoteRoot.js
+++ b/src/components/NoteRoot/NoteRoot.js
@@ -75,7 +75,7 @@ class NoteRoot extends React.Component {
         }
         <div className="time">
           {(sortNotesBy !== 'time' || isNoteExpanded) &&
-            dayjs(annotation.DateCreated || new Date()).format(noteDateFormat || 'MMM D, h:mma')
+            dayjs(annotation.DateCreated || new Date()).format(noteDateFormat)
           }
           {numberOfReplies > 0 &&
             ` (${numberOfReplies})`

--- a/src/index.js
+++ b/src/index.js
@@ -168,6 +168,7 @@ if (window.CanvasRenderingContext2D) {
           searchTextFull: apis.searchTextFull(store),
           selectors: apis.getSelectors(store),
           setAdminUser: apis.setAdminUser,
+          setNoteDateFormat: apis.setNoteDateFormat(store),
           setAnnotationUser: apis.setAnnotationUser,
           setTheme: apis.setTheme,
           setCurrentPageNumber: apis.setCurrentPageNumber,

--- a/src/redux/actions/exposedActions.js
+++ b/src/redux/actions/exposedActions.js
@@ -70,5 +70,6 @@ export const setActiveLeftPanel = dataElement => (dispatch, getState) => {
   }
 };
 export const setSortNotesBy = sortNotesBy => ({ type: 'SET_SORT_NOTES_BY', payload: { sortNotesBy } });
+export const setNoteDateFormat = noteDateFormat => ({ type: 'SET_NOTE_DATE_FORMAT', payload: { noteDateFormat } });
 export const updateTool = (toolName, properties) => ({ type: 'UPDATE_TOOL', payload: { toolName, properties } });
 export const setCustomPanel = newPanel => ({ type: 'SET_CUSTOM_PANEL', payload: { newPanel } });

--- a/src/redux/initialState.js
+++ b/src/redux/initialState.js
@@ -151,6 +151,7 @@ export default {
     isDocumentLoaded: false,
     isReadOnly: getHashParams('readonly', false),
     customPanels: [],
+    noteDateFormat: 'MMM D, h:mma'
   },
   search: {
     listeners: [],

--- a/src/redux/reducers/viewerReducer.js
+++ b/src/redux/reducers/viewerReducer.js
@@ -72,6 +72,8 @@ export default initialState => (state = initialState, action) => {
       return { ...state, currentPage: payload.currentPage };
     case 'SET_SORT_NOTES_BY':
       return { ...state, sortNotesBy: payload.sortNotesBy };
+    case 'SET_NOTE_DATE_FORMAT':
+      return { ...state, noteDateFormat: payload.noteDateFormat };
     case 'SET_FULL_SCREEN':
       return { ...state, isFullScreen: payload.isFullScreen };
     case 'SET_HEADER_ITEMS':

--- a/src/redux/selectors/exposedSelectors.js
+++ b/src/redux/selectors/exposedSelectors.js
@@ -27,6 +27,7 @@ export const getZoom = state => state.viewer.zoom;
 export const getDisplayMode = state => state.viewer.displayMode;
 export const getCurrentPage = state => state.viewer.currentPage;
 export const getSortNotesBy = state => state.viewer.sortNotesBy;
+export const getNoteDateFormat = state => state.viewer.noteDateFormat;
 export const isFullScreen = state => state.viewer.isFullScreen;
 export const doesDocumentAutoLoad = state => state.viewer.doesAutoLoad;
 export const isDocumentLoaded = state => state.viewer.isDocumentLoaded;


### PR DESCRIPTION
This adds the public API function `setNoteDateFormat` for customizing the date format string used for the creation date of annotations and replies.

### Motivation
This is especially useful for customers of different locales as its possible to choose an appropriate format string.

### Test
`readerControl.setNoteDateFormat('DD.MM.YYYY HH:MM')`

### Discussion
Please let me know if the name of the API should be altered or if there is a better way to add such API.

Thanks for reviewing this PR :)