### PR TITLE
[update] Resolves #49 by adding a function for rendering custom thumbnail content

### DIFF
--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -61,6 +61,7 @@ import disableTools from './disableTools';
 import isToolDisabled from './isToolDisabled';
 import setNotesPanelSort from './setNotesPanelSort';
 import updateOutlines from './updateOutlines';
+import setThumbnailCustomContentRenderer from './setThumbnailCustomContentRenderer';
 
 export default {
   loadDocument,
@@ -125,5 +126,6 @@ export default {
   disableTools,
   isToolDisabled,
   setNotesPanelSort,
-  updateOutlines
+  updateOutlines,
+  setThumbnailCustomContentRenderer
 };

--- a/src/apis/setThumbnailCustomContentRenderer.js
+++ b/src/apis/setThumbnailCustomContentRenderer.js
@@ -1,0 +1,5 @@
+import actions from 'actions';
+
+export default store => thumbnailCustomContentRenderer => {
+  store.dispatch(actions.setThumbnailCustomContentRenderer(thumbnailCustomContentRenderer));
+};

--- a/src/components/Thumbnail/Thumbnail.js
+++ b/src/components/Thumbnail/Thumbnail.js
@@ -18,6 +18,7 @@ class Thumbnail extends React.PureComponent {
     onCancel: PropTypes.func.isRequired,
     onRemove: PropTypes.func.isRequired,
     closeElement: PropTypes.func.isRequired,
+    customContentRenderer: PropTypes.func
   }
 
   constructor(props) {
@@ -59,20 +60,26 @@ class Thumbnail extends React.PureComponent {
   }
 
   render() {
-    const { index, currentPage } = this.props;
+    const { index, currentPage, customContentRenderer } = this.props;
     const isActive = currentPage === index + 1;
 
     return (
       <div className={`Thumbnail ${isActive ? 'active' : ''}`}>
         <div className="container" ref={this.thumbContainer} onClick={this.handleClick}></div>
         <div className="page-number">{index + 1}</div>
+        { customContentRenderer &&
+        <div className="customContent">
+          {customContentRenderer(index, React)}
+        </div>
+        }
       </div>
     );
   }
 }
 
 const mapStateToProps = state => ({
-  currentPage: selectors.getCurrentPage(state)
+  currentPage: selectors.getCurrentPage(state),
+  customContentRenderer: selectors.getThumbnailCustomContentRenderer(state)
 });
 
 const mapDispatchToProps = {

--- a/src/index.js
+++ b/src/index.js
@@ -181,6 +181,7 @@ if (window.CanvasRenderingContext2D) {
           setReadOnly: apis.setReadOnly,
           setShowSideWindow: apis.setShowSideWindow(store),
           setSideWindowVisibility: apis.setSideWindowVisibility(store),
+          setThumbnailCustomContentRenderer: apis.setThumbnailCustomContentRenderer(store),
           setToolMode: apis.setToolMode(store),
           setZoomLevel: apis.setZoomLevel,
           toggleFullScreen: apis.toggleFullScreen,

--- a/src/redux/actions/exposedActions.js
+++ b/src/redux/actions/exposedActions.js
@@ -72,3 +72,6 @@ export const setActiveLeftPanel = dataElement => (dispatch, getState) => {
 export const setSortNotesBy = sortNotesBy => ({ type: 'SET_SORT_NOTES_BY', payload: { sortNotesBy } });
 export const updateTool = (toolName, properties) => ({ type: 'UPDATE_TOOL', payload: { toolName, properties } });
 export const setCustomPanel = newPanel => ({ type: 'SET_CUSTOM_PANEL', payload: { newPanel } });
+export const setThumbnailCustomContentRenderer = thumbnailCustomContentRenderer => {
+  return ({type: 'SET_THUMBNAIL_CUSTOM_CONTENT_RENDERER', payload: {thumbnailCustomContentRenderer}});
+};

--- a/src/redux/reducers/viewerReducer.js
+++ b/src/redux/reducers/viewerReducer.js
@@ -142,6 +142,8 @@ export default initialState => (state = initialState, action) => {
       }
       case 'SET_CUSTOM_PANEL': 
         return { ...state, customPanels: [ ...state.customPanels, payload.newPanel ] };
+      case 'SET_THUMBNAIL_CUSTOM_CONTENT_RENDERER':
+        return { ...state, thumbnailCustomContentRenderer: payload.thumbnailCustomContentRenderer };
     default:
       return state;
   }

--- a/src/redux/selectors/exposedSelectors.js
+++ b/src/redux/selectors/exposedSelectors.js
@@ -40,6 +40,7 @@ export const getDisabledCustomPanelTabs = state => {
     return disabledTabs;
   }, []);
 };
+export const getThumbnailCustomContentRenderer = state => state.viewer.thumbnailCustomContentRenderer;
 
 // document
 export const getDocument = state => state.document;


### PR DESCRIPTION
This adds the public API function `setThumbnailCustomContentRender` for adding custom DOM elements to the thumbnail container during rendering.

### Motivation
We need to be able to add custom elements (in pur case individual download buttons) next to the thumbnails in the panel. As this could be a usecase for more users we would like to introduce this API (and because we want to maintain upgradability by not altering the React sources ourselves).

### Test
```
readerControl.setThumbnailCustomContentRenderer(function (index, react) {
      return react.createElement('p', null, 'Custom page: ' + index);
});
```

### Discussion
Please let me know if the name of the API should be altered or if there is a better way to add such API.

Thanks for reviewing this PR :)