### PR TITLE
Pull request to fix PageNav display

### DIFF
--- a/src/components/PageNavOverlay/PageNavOverlay.js
+++ b/src/components/PageNavOverlay/PageNavOverlay.js
@@ -32,9 +32,7 @@ class PageNavOverlay extends React.PureComponent {
     const { currentPage, pageLabels } = this.props;
     
     const isCustomPageLabels = prevProps.pageLabels !== this.props.pageLabels && prevProps.pageLabels.length !== 0;
-    if (isCustomPageLabels) {
-      this.setState({ isCustomPageLabels: true });
-    }
+    this.setState({ isCustomPageLabels });
 
     if (prevProps.currentPage !== this.props.currentPage || prevProps.pageLabels !== this.props.pageLabels) {
       this.setState({ input: pageLabels[currentPage - 1] });
@@ -78,7 +76,7 @@ class PageNavOverlay extends React.PureComponent {
 
     const inputWidth = totalPages.toString().length * 10;
     const className = getClassName(`Overlay PageNavOverlay ${isLeftPanelOpen && !isLeftPanelDisabled ? 'shifted' : ''}`, this.props);
-    
+
     return (
       <div className={className} data-element="pageNavOverlay" onClick={this.onClick}>
         <form onSubmit={this.onSubmit} onBlur={this.onBlur}>
@@ -94,13 +92,13 @@ class PageNavOverlay extends React.PureComponent {
 }
 
 const mapStateToProps = state => ({
-  isLeftPanelDisabled: selectors.isElementDisabled(state, 'leftPanel'),
-  isLeftPanelOpen: selectors.isElementOpen(state, 'leftPanel'),
-  isDisabled: selectors.isElementDisabled(state, 'pageNavOverlay'),
-  isOpen: selectors.isElementOpen(state, 'pageNavOverlay'),
-  currentPage: selectors.getCurrentPage(state),
-  totalPages: selectors.getTotalPages(state),
-  pageLabels: selectors.getPageLabels(state)
-});
+    isLeftPanelDisabled: selectors.isElementDisabled(state, 'leftPanel'),
+    isLeftPanelOpen: selectors.isElementOpen(state, 'leftPanel'),
+    isDisabled: selectors.isElementDisabled(state, 'pageNavOverlay'),
+    isOpen: selectors.isElementOpen(state, 'pageNavOverlay'),
+    currentPage: selectors.getCurrentPage(state),
+    totalPages: selectors.getTotalPages(state),
+    pageLabels: selectors.getPageLabels(state)
+  });
 
 export default connect(mapStateToProps)(PageNavOverlay);

--- a/src/components/PageNavOverlay/PageNavOverlay.js
+++ b/src/components/PageNavOverlay/PageNavOverlay.js
@@ -92,13 +92,13 @@ class PageNavOverlay extends React.PureComponent {
 }
 
 const mapStateToProps = state => ({
-    isLeftPanelDisabled: selectors.isElementDisabled(state, 'leftPanel'),
-    isLeftPanelOpen: selectors.isElementOpen(state, 'leftPanel'),
-    isDisabled: selectors.isElementDisabled(state, 'pageNavOverlay'),
-    isOpen: selectors.isElementOpen(state, 'pageNavOverlay'),
-    currentPage: selectors.getCurrentPage(state),
-    totalPages: selectors.getTotalPages(state),
-    pageLabels: selectors.getPageLabels(state)
-  });
+  isLeftPanelDisabled: selectors.isElementDisabled(state, 'leftPanel'),
+  isLeftPanelOpen: selectors.isElementOpen(state, 'leftPanel'),
+  isDisabled: selectors.isElementDisabled(state, 'pageNavOverlay'),
+  isOpen: selectors.isElementOpen(state, 'pageNavOverlay'),
+  currentPage: selectors.getCurrentPage(state),
+  totalPages: selectors.getTotalPages(state),
+  pageLabels: selectors.getPageLabels(state)
+});
 
 export default connect(mapStateToProps)(PageNavOverlay);

--- a/src/event-listeners/getDefaultPageLabels.js
+++ b/src/event-listeners/getDefaultPageLabels.js
@@ -1,0 +1,1 @@
+export default totalPages => new Array(totalPages).fill().map((_, index) => `${index + 1}`);

--- a/src/event-listeners/onBeforeDocumentLoaded.js
+++ b/src/event-listeners/onBeforeDocumentLoaded.js
@@ -1,6 +1,8 @@
 import core from 'core';
 import actions from 'actions';
 
+import getDefaultPageLabels from 'helpers/getDefaultPageLabels';
+
 export default dispatch => () => {
   // if we are opening an password-protected pdf,
   // this event will only be trigger after we enter the correct password, so it's safe to close this modal here
@@ -11,11 +13,10 @@ export default dispatch => () => {
     core.setDisplayMode(window.CoreControls.DisplayModes.Single);
   }
 
-  dispatch(actions.setPageLabels(getDefaultPageLabels(totalPages)));
+  //totalPages is 1 for '.docX' and '.pptx' at this point, will use use 'setPageLabels' again later during 'onLayoutChanged' to set correct value
+  dispatch(actions.setPageLabels(getDefaultPageLabels(totalPages))); 
   dispatch(actions.setTotalPages(totalPages));
   
   const currentPage = core.getCurrentPage();
   dispatch(actions.setCurrentPage(currentPage));
 };
-
-const getDefaultPageLabels = totalPages => new Array(totalPages).fill().map((_, index) => `${index + 1}`); 

--- a/src/event-listeners/onLayoutChanged.js
+++ b/src/event-listeners/onLayoutChanged.js
@@ -1,10 +1,12 @@
 import core from 'core';
 import actions from 'actions';
+import getDefaultPageLabels from 'helpers/getDefaultPageLabels';
 
 export default dispatch => (e, { added, removed }) => {
   if (added.length || removed.length) {
     const totalPages = core.getTotalPages();
 
+    dispatch(actions.setPageLabels(getDefaultPageLabels(totalPages)));
     dispatch(actions.setTotalPages(totalPages));
   }
 };


### PR DESCRIPTION
The page nav would go from "(1/3)" to "1 (1/3)" when switching between files. 

![image](https://user-images.githubusercontent.com/45575633/49413776-ec977680-f725-11e8-97d5-043f83ed1fce.png)

This pull request is to fix that from happening. 