### PR TITLE
[bugfix] fixes #66

### DIFF
--- a/src/components/PageNavOverlay/PageNavOverlay.js
+++ b/src/components/PageNavOverlay/PageNavOverlay.js
@@ -31,9 +31,9 @@ class PageNavOverlay extends React.PureComponent {
   componentDidUpdate(prevProps) {
     const { currentPage, pageLabels } = this.props;
     
-    const isCustomPageLabels = prevProps.pageLabels !== this.props.pageLabels && prevProps.pageLabels.length !== 0;
-    if (isCustomPageLabels) {
-      this.setState({ isCustomPageLabels: true });
+    if (prevProps.pageLabels !== pageLabels) {
+      const isCustomPageLabels = pageLabels.some((label, index) => label !== `${index + 1}`);
+      this.setState({ isCustomPageLabels });   
     }
 
     if (prevProps.currentPage !== this.props.currentPage || prevProps.pageLabels !== this.props.pageLabels) {

--- a/src/event-listeners/onBeforeDocumentLoaded.js
+++ b/src/event-listeners/onBeforeDocumentLoaded.js
@@ -1,5 +1,6 @@
 import core from 'core';
 import actions from 'actions';
+import getDefaultPageLabels from 'helpers/getDefaultPageLabels';
 
 export default dispatch => () => {
   // if we are opening an password-protected pdf,
@@ -17,5 +18,3 @@ export default dispatch => () => {
   const currentPage = core.getCurrentPage();
   dispatch(actions.setCurrentPage(currentPage));
 };
-
-const getDefaultPageLabels = totalPages => new Array(totalPages).fill().map((_, index) => `${index + 1}`); 

--- a/src/event-listeners/onLayoutChanged.js
+++ b/src/event-listeners/onLayoutChanged.js
@@ -1,10 +1,12 @@
 import core from 'core';
 import actions from 'actions';
+import getDefaultPageLabels from 'helpers/getDefaultPageLabels';
 
 export default dispatch => (e, { added, removed }) => {
   if (added.length || removed.length) {
     const totalPages = core.getTotalPages();
 
+    dispatch(actions.setPageLabels(getDefaultPageLabels(totalPages)));
     dispatch(actions.setTotalPages(totalPages));
   }
 };

--- a/src/helpers/getDefaultPageLabels.js
+++ b/src/helpers/getDefaultPageLabels.js
@@ -1,0 +1,2 @@
+
+export default (totalPages) => new Array(totalPages).fill().map((_, index) => `${index + 1}`); 


### PR DESCRIPTION
This pull request is to fix issue #66 . The solution was:

- Change the way we were setting the 'isCustomPageLabels' variable (check if any custom labels are being used)
- Updated the 'onLayoutChanged' event to dispatched the 'setPageLabels' action. For '.pptx' and '.docx' file, the page count (and page labels created) were incorrect during the "onDocumentReady" event but should be correct when the 'onLayoutChanged' trigger. 