### PR TITLE
[update] Resolves #62 by having annotation popup reappear on mouse up

### DIFF
--- a/src/components/AnnotationPopup/AnnotationPopup.js
+++ b/src/components/AnnotationPopup/AnnotationPopup.js
@@ -97,6 +97,7 @@ class AnnotationPopup extends React.PureComponent {
         canModify: core.canModify(annotation)
       });
     } else {
+      //this.props.closeElement('annotationPopup');
       this.setState({ ...this.initialState });
     }
   }

--- a/src/components/AnnotationPopup/AnnotationPopup.js
+++ b/src/components/AnnotationPopup/AnnotationPopup.js
@@ -97,7 +97,7 @@ class AnnotationPopup extends React.PureComponent {
         canModify: core.canModify(annotation)
       });
     } else {
-      //this.props.closeElement('annotationPopup');
+      this.props.closeElement('annotationPopup');
       this.setState({ ...this.initialState });
     }
   }

--- a/src/components/AnnotationPopup/AnnotationPopup.js
+++ b/src/components/AnnotationPopup/AnnotationPopup.js
@@ -37,12 +37,15 @@ class AnnotationPopup extends React.PureComponent {
       left: 0,
       top: 0,
       canModify: false,
-      isStylePopupOpen: false
+      isStylePopupOpen: false,
+      isMouseLeftDown: false,
     };
     this.state = this.initialState;
   }
 
   componentDidMount() {
+    core.addEventListener('mouseLeftUp', this.onMouseLeftUp);
+    core.addEventListener('mouseLeftDown', this.onMouseLeftDown);
     core.addEventListener('annotationSelected', this.onAnnotationSelected);
     core.addEventListener('annotationChanged', this.onAnnotationChanged);
     core.addEventListener('updateAnnotationPermission', this.onUpdateAnnotationPermission);
@@ -50,16 +53,19 @@ class AnnotationPopup extends React.PureComponent {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const selectedAnAnnotation = Object.keys(this.state.annotation).length !== 0 && prevState.annotation.Id !== this.state.annotation.Id;
+    const { isMouseLeftDown } = this.state;
+    
+    const isAnnotationSelected = Object.keys(this.state.annotation).length !== 0;
+    const isClosingAnnotationPopup = this.props.isOpen === false && this.props.isOpen !== prevProps.isOpen;
     const isStylePopupOpen = !prevState.isStylePopupOpen && this.state.isStylePopupOpen;
     const isContainerShifted = prevProps.isLeftPanelOpen !== this.props.isLeftPanelOpen || prevProps.isRightPanelOpen !== this.props.isRightPanelOpen;
 
-    if (selectedAnAnnotation && !this.props.isDisabled || isStylePopupOpen) {
+    if (isAnnotationSelected && !isMouseLeftDown && !isContainerShifted && !isClosingAnnotationPopup && !this.props.isDisabled || isStylePopupOpen) {
       this.positionAnnotationPopup();
       this.props.openElement('annotationPopup');
     }
 
-    if (isContainerShifted) {
+    if (isContainerShifted) { //closing because we can't correctly reposition the popup on panel transition
       this.props.closeElement('annotationPopup');
     }
 
@@ -67,10 +73,20 @@ class AnnotationPopup extends React.PureComponent {
   }
 
   componentWillUnmount() {
+    core.removeEventListener('mouseLeftUp', this.onMouseLeftUp);
+    core.removeEventListener('mouseLeftDown', this.onMouseLeftDown);
     core.removeEventListener('annotationSelected', this.onAnnotationSelected);
     core.removeEventListener('annotationChanged', this.onAnnotationChanged);
     core.removeEventListener('updateAnnotationPermission', this.onUpdateAnnotationPermission);
     window.removeEventListener('resize', this.handleWindowResize);
+  }
+
+  onMouseLeftUp = () => {
+    this.setState({ isMouseLeftDown:false });
+  }
+
+  onMouseLeftDown = () => {
+    this.setState({ isMouseLeftDown:true });
   }
 
   onAnnotationSelected = (e, annotations, action) => {
@@ -81,7 +97,6 @@ class AnnotationPopup extends React.PureComponent {
         canModify: core.canModify(annotation)
       });
     } else {
-      this.props.closeElement('annotationPopup');
       this.setState({ ...this.initialState });
     }
   }


### PR DESCRIPTION
Updated the 'componentDidUpdate' of the AnnotationPopup to have it open on mouse up when needed. Before it only open when a new annotation was selected. 