### PR TITLE
Fix issue where two files would be downloaded when using WebViewer Se…

### DIFF
--- a/src/helpers/downloadPdf.js
+++ b/src/helpers/downloadPdf.js
@@ -36,6 +36,7 @@ export default (dispatch, documentPath = 'document', filename, includeAnnotation
         downloadIframe.width = 0;
         downloadIframe.height = 0;
         downloadIframe.id = 'download-iframe';
+        downloadIframe.src = null;
         document.body.appendChild(downloadIframe);
         bbURLPromise.then(result => {
           downloadIframe.src = result.url;


### PR DESCRIPTION
…rver

The downloadIframe is being reused and the src from the previous download is still set when appending it for the next download