### PR TITLE
Fix issue where the annotationsLoadedPromise never resolves

### DIFF
--- a/src/helpers/setupLoadAnnotationsFromServer.js
+++ b/src/helpers/setupLoadAnnotationsFromServer.js
@@ -1,6 +1,6 @@
 import core from 'core';
 
-export default store =>  {  
+export default store =>  {
   const state = store.getState();
   const { serverUrl, serverUrlHeaders } = state.advanced;
 
@@ -15,6 +15,7 @@ export default store =>  {
     if (window.readerControl.serverFailed) {
       callback(originalData);
     } else if (window.readerControl.loadedFromServer) {
+      callback('');
       return;
     }
 


### PR DESCRIPTION
If the annotations have already been loaded from the server then we can just return an empty string which will continue on the annotation loading process