### PR TITLE
Fix issue where registering a tool can trigger errors because it happ…

### DIFF
--- a/src/apis/registerTool.js
+++ b/src/apis/registerTool.js
@@ -2,8 +2,8 @@ import core from 'core';
 import actions from 'actions';
 
 export default store => tool => {
-  registerToolInRedux(store, tool);
   registerToolInToolModeMap(tool);
+  registerToolInRedux(store, tool);
 };
 
 const registerToolInRedux = (store, tool) => {


### PR DESCRIPTION
…ens before it's in the toolmode map

Registering the tool in redux can trigger a synchronous state change where some APIs can try to access the tool before it was added to the toolmode map
Instead we can add it to the map first and then register in redux