### PR TITLE
Fix issue with updateAnnotationPermission events triggering when document is unloaded and annotation was previously selected

### DIFF
--- a/src/components/AnnotationPopup/AnnotationPopup.js
+++ b/src/components/AnnotationPopup/AnnotationPopup.js
@@ -48,12 +48,13 @@ class AnnotationPopup extends React.PureComponent {
     core.addEventListener('annotationSelected', this.onAnnotationSelected);
     core.addEventListener('annotationChanged', this.onAnnotationChanged);
     core.addEventListener('updateAnnotationPermission', this.onUpdateAnnotationPermission);
+    core.addEventListener('documentUnloaded', this.onDocumentUnloaded);
     window.addEventListener('resize', this.handleWindowResize);
   }
 
   componentDidUpdate(prevProps, prevState) {
     const { isMouseLeftDown } = this.state;
-    
+
     const isAnnotationSelected = Object.keys(this.state.annotation).length !== 0;
     const isClosingAnnotationPopup = this.props.isOpen === false && this.props.isOpen !== prevProps.isOpen;
     const isStylePopupOpen = !prevState.isStylePopupOpen && this.state.isStylePopupOpen;
@@ -75,7 +76,13 @@ class AnnotationPopup extends React.PureComponent {
     core.removeEventListener('annotationSelected', this.onAnnotationSelected);
     core.removeEventListener('annotationChanged', this.onAnnotationChanged);
     core.removeEventListener('updateAnnotationPermission', this.onUpdateAnnotationPermission);
+    core.removeEventListener('documentUnloaded', this.onDocumentUnloaded);
     window.removeEventListener('resize', this.handleWindowResize);
+  }
+
+  close = () => {
+    this.props.closeElement('annotationPopup');
+    this.setState({ ...this.initialState });
   }
 
   onMouseLeftUp = () => {
@@ -86,6 +93,10 @@ class AnnotationPopup extends React.PureComponent {
     this.setState({ isMouseLeftDown:true });
   }
 
+  onDocumentUnloaded = () => {
+    this.close();
+  }
+
   onAnnotationSelected = (e, annotations, action) => {
     if (action === 'selected' && annotations.length === 1) {
       const annotation = annotations[0];
@@ -94,8 +105,7 @@ class AnnotationPopup extends React.PureComponent {
         canModify: core.canModify(annotation)
       });
     } else {
-      this.props.closeElement('annotationPopup');
-      this.setState({ ...this.initialState });
+      this.close();
     }
   }
 

--- a/src/components/PrintModal/PrintModal.js
+++ b/src/components/PrintModal/PrintModal.js
@@ -96,14 +96,14 @@ class PrintModal extends React.PureComponent {
       console.error(e);
     });
   }
-  
+
   setPrintQuality = () => {
     window.utils.setCanvasMultiplier(this.props.printQuality);
   }
 
   creatingPages = () => {
     const creatingPages = [];
-    
+
     this.pendingCanvases = [];
     this.state.pagesToPrint.forEach(pageNumber => {
       creatingPages.push(this.creatingImage(pageNumber));
@@ -232,7 +232,7 @@ class PrintModal extends React.PureComponent {
     return new Promise(resolve => {
       const container = document.createElement('div');
       container.className = 'page__container';
-      
+
       const header =  document.createElement('div');
       header.className = 'page__header';
       header.innerHTML = `Page ${pageNumber}`;
@@ -247,14 +247,14 @@ class PrintModal extends React.PureComponent {
       resolve(container);
     });
   }
-  
+
   getNote = annotation => {
     const note = document.createElement('div');
     note.className = 'note';
 
     const noteRoot = document.createElement('div');
     noteRoot.className = 'note__root';
-    
+
     const noteRootInfo = document.createElement('div');
     noteRootInfo.className = 'note__info--with-icon';
 
@@ -283,7 +283,7 @@ class PrintModal extends React.PureComponent {
 
   getNoteInfo = annotation => {
     const info = document.createElement('div');
-    
+
     info.className = 'note__info';
     info.innerHTML = `
       Author: ${annotation.Author || ''} &nbsp;&nbsp;
@@ -292,7 +292,7 @@ class PrintModal extends React.PureComponent {
     `;
     return info;
   }
-  
+
   getNoteContent = annotation => {
     const contentElement = document.createElement('div');
     const contentText = annotation.getContents();
@@ -343,7 +343,7 @@ class PrintModal extends React.PureComponent {
     const { count, pagesToPrint } = this.state;
     const className = getClassName('Modal PrintModal', this.props);
     const customPagesLabelElement = <input ref={this.customInput} type="text" placeholder={t('message.customPrintPlaceholder')} onFocus={this.onFocus}/>;
-    const isPrinting = count > 0;
+    const isPrinting = count >= 0;
 
     return (
       <div className={className} data-element="printModal" onClick={this.closePrintModal}>

--- a/src/components/PrintModal/PrintModal.js
+++ b/src/components/PrintModal/PrintModal.js
@@ -343,7 +343,7 @@ class PrintModal extends React.PureComponent {
     const { count, pagesToPrint } = this.state;
     const className = getClassName('Modal PrintModal', this.props);
     const customPagesLabelElement = <input ref={this.customInput} type="text" placeholder={t('message.customPrintPlaceholder')} onFocus={this.onFocus}/>;
-    const isPrinting = count >= 0;
+    const isPrinting = count > 0;
 
     return (
       <div className={className} data-element="printModal" onClick={this.closePrintModal}>

--- a/src/components/PrintModal/PrintModal.js
+++ b/src/components/PrintModal/PrintModal.js
@@ -96,14 +96,14 @@ class PrintModal extends React.PureComponent {
       console.error(e);
     });
   }
-
+  
   setPrintQuality = () => {
     window.utils.setCanvasMultiplier(this.props.printQuality);
   }
 
   creatingPages = () => {
     const creatingPages = [];
-
+    
     this.pendingCanvases = [];
     this.state.pagesToPrint.forEach(pageNumber => {
       creatingPages.push(this.creatingImage(pageNumber));
@@ -232,7 +232,7 @@ class PrintModal extends React.PureComponent {
     return new Promise(resolve => {
       const container = document.createElement('div');
       container.className = 'page__container';
-
+      
       const header =  document.createElement('div');
       header.className = 'page__header';
       header.innerHTML = `Page ${pageNumber}`;
@@ -247,14 +247,14 @@ class PrintModal extends React.PureComponent {
       resolve(container);
     });
   }
-
+  
   getNote = annotation => {
     const note = document.createElement('div');
     note.className = 'note';
 
     const noteRoot = document.createElement('div');
     noteRoot.className = 'note__root';
-
+    
     const noteRootInfo = document.createElement('div');
     noteRootInfo.className = 'note__info--with-icon';
 
@@ -283,7 +283,7 @@ class PrintModal extends React.PureComponent {
 
   getNoteInfo = annotation => {
     const info = document.createElement('div');
-
+    
     info.className = 'note__info';
     info.innerHTML = `
       Author: ${annotation.Author || ''} &nbsp;&nbsp;
@@ -292,7 +292,7 @@ class PrintModal extends React.PureComponent {
     `;
     return info;
   }
-
+  
   getNoteContent = annotation => {
     const contentElement = document.createElement('div');
     const contentText = annotation.getContents();


### PR DESCRIPTION
If the annotation popup was visible when the document was unloaded then the AnnotationPopup retained the state about the selected annotation

This could cause errors if an event came in and the popup thought that an annotation was selected