### PR TITLE
[bugfix] Fix issues with enabling/disabling tools causing unexpected results

### DIFF
--- a/src/apis/enableAnnotations.js
+++ b/src/apis/enableAnnotations.js
@@ -17,13 +17,12 @@ export default store => (enable = true) =>  {
     if (!core.isCreateRedactionEnabled()) {
       elements = elements.filter(ele => ele !== 'redactionButton');
     }
-
-    core.showAnnotations(core.getAnnotationsList());
     getAnnotationCreateToolNames().forEach(toolName => {
       core.getTool(toolName).disabled = false;
     });
 
     store.dispatch(actions.enableElements(elements, PRIORITY_ONE));
+    core.showAnnotations(core.getAnnotationsList());
 
   } else {
     console.warn('enableAnnotations(false) is deprecated, please use disableAnnotations() instead');

--- a/src/apis/enableAnnotations.js
+++ b/src/apis/enableAnnotations.js
@@ -2,18 +2,29 @@ import core from 'core';
 import disableAnnotations from './disableAnnotations';
 import getAnnotationRelatedElements from 'helpers/getAnnotationRelatedElements';
 import { PRIORITY_ONE } from 'constants/actionPriority';
+import { getAnnotationCreateToolNames } from 'constants/map';
+
 import actions from 'actions';
 
 export default store => (enable = true) =>  {
-  const elements = [
+  let elements = [
     'notesPanel',
     'notesPanelButton',
     ...getAnnotationRelatedElements(store.getState())
   ];
 
   if (enable) {
-    store.dispatch(actions.enableElements(elements, PRIORITY_ONE));
+    if (!core.isCreateRedactionEnabled()) {
+      elements = elements.filter(ele => ele !== 'redactionButton');
+    }
+
     core.showAnnotations(core.getAnnotationsList());
+    getAnnotationCreateToolNames().forEach(toolName => {
+      core.getTool(toolName).disabled = false;
+    });
+
+    store.dispatch(actions.enableElements(elements, PRIORITY_ONE));
+
   } else {
     console.warn('enableAnnotations(false) is deprecated, please use disableAnnotations() instead');
     disableAnnotations(store)();

--- a/src/apis/enableAnnotations.js
+++ b/src/apis/enableAnnotations.js
@@ -3,7 +3,6 @@ import disableAnnotations from './disableAnnotations';
 import getAnnotationRelatedElements from 'helpers/getAnnotationRelatedElements';
 import { PRIORITY_ONE } from 'constants/actionPriority';
 import { getAnnotationCreateToolNames } from 'constants/map';
-
 import actions from 'actions';
 
 export default store => (enable = true) =>  {
@@ -23,7 +22,6 @@ export default store => (enable = true) =>  {
 
     store.dispatch(actions.enableElements(elements, PRIORITY_ONE));
     core.showAnnotations(core.getAnnotationsList());
-
   } else {
     console.warn('enableAnnotations(false) is deprecated, please use disableAnnotations() instead');
     disableAnnotations(store)();

--- a/src/apis/enableRedaction.js
+++ b/src/apis/enableRedaction.js
@@ -1,5 +1,6 @@
 import actions from 'actions';
 import core from 'core';
+import disableRedaction from './disableRedaction';
 
 export default store => (enable = true) =>  {
 
@@ -11,7 +12,6 @@ export default store => (enable = true) =>  {
       console.warn('Full api is not enabled, applying redactions is disabled');
     }
   } else {
-    store.dispatch(actions.disableElement('redactionButton', 1));
-    core.enableRedaction(false);
+    disableRedaction(store)();
   }
 };

--- a/src/components/RedactionOverlay/RedactionOverlay.js
+++ b/src/components/RedactionOverlay/RedactionOverlay.js
@@ -45,7 +45,9 @@ class RedactionOverlay extends React.PureComponent {
 
       core.setToolMode('AnnotationCreateRedaction');
       setActiveToolGroup('redactTools');
-      this.setState(getOverlayPositionBasedOn('redactionButton', this.overlay));
+      if (this.overlay && this.overlay.current) { 
+        this.setState(getOverlayPositionBasedOn('redactionButton', this.overlay));
+      }
     }
   }
 

--- a/src/helpers/setDefaultDisabledElements.js
+++ b/src/helpers/setDefaultDisabledElements.js
@@ -17,6 +17,7 @@ export default store => {
   disableElementsIfToolBarDisabled(dispatch);
   disableElementsIfDesktop(dispatch);
   disableElementsIfMeasurementsDisabled(dispatch);
+  disableElementsIfRedactionsDisabled(dispatch);
 };
 
 const disableElementsPassedByConstructor = (state, dispatch) => {
@@ -89,6 +90,13 @@ const disableElementsIfMeasurementsDisabled = dispatch => {
   const measurementsDisabled = !getHashParams('enableMeasurement', false);
   if (measurementsDisabled) {
     dispatch(actions.disableElement('measurementToolGroupButton', PRIORITY_ONE));
+  }
+};
+
+const disableElementsIfRedactionsDisabled = dispatch => {
+  const redactionsDisabled = !(getHashParams('enableRedaction', false) || core.isCreateRedactionEnabled());
+  if (redactionsDisabled) {
+    dispatch(actions.disableElement('redactionButton', PRIORITY_ONE));
   }
 };
 

--- a/src/redux/actions/internalActions.js
+++ b/src/redux/actions/internalActions.js
@@ -1,7 +1,7 @@
 import getFilteredDataElements from 'helpers/getFilteredDataElements';
 import { isIOS, isAndroid } from 'helpers/device';
 import selectors from 'selectors';
-
+import core from 'core';
 
 // viewer
 export const disableElement = (dataElement, priority) => (dispatch, getState) => {
@@ -29,7 +29,12 @@ export const enableElement = (dataElement, priority) => (dispatch, getState) => 
   }
 };
 export const enableElements = (dataElements, priority) => (dispatch, getState) => {
-  const filteredDataElements = getFilteredDataElements(getState(), dataElements, priority);
+  let filteredDataElements = getFilteredDataElements(getState(), dataElements, priority);
+
+  if (!core.isCreateRedactionEnabled()) {
+    filteredDataElements = filteredDataElements.filter(ele => ele !== 'redactionButton');
+  }
+
   dispatch({ type: 'ENABLE_ELEMENTS', payload: { dataElements: filteredDataElements, priority } });
 };
 export const setActiveToolNameAndStyle = toolObject => (dispatch, getState) => {

--- a/src/redux/initialState.js
+++ b/src/redux/initialState.js
@@ -12,12 +12,7 @@ import Button from 'components/Button';
 
 export default {
   viewer: {
-    disabledElements: {
-      'redactionButton': {
-        //redaction button starts hidden and show up when document is loaded
-        disabled: true
-      }
-    },
+    disabledElements: { },
     openElements: {
       header: true
     },


### PR DESCRIPTION
This commit is to fix some bugs where enabling/disabling tools was doing odd things (only enabling redactions). The big change that might cause issues is, I noticed in disableAnnotation.js we were doing 

`  getAnnotationCreateToolNames().forEach(toolName => {
    core.getTool(toolName).disabled = true;
  });`

However we aren't enabling them in enableAnnotation.js (I added it in this commit)