### PR TITLE
[Bugfix] Fix problem with redaction in IE

### DIFF
--- a/src/helpers/applyRedactions.js
+++ b/src/helpers/applyRedactions.js
@@ -36,8 +36,9 @@ const webViewerApply = (annotations, dispatch) => {
         message,
         title,
         confirmBtnText,
-        onConfirm: () => { 
-            return core.applyRedactions(annotations).catch(err => fireError(err)); 
+        onConfirm: () => {
+            core.applyRedactions(annotations).catch(err => fireError(err)); 
+            return Promise.resolve();
         }
     };
 


### PR DESCRIPTION
This is kind of an band aid fix for IE. Since IE is slow, the user might press "Apply" more than once which throw an error. A better solution for later would be to show the 'loadingModal' till the promise from 'applyRedactions' is resolved, but I was having problem getting that to work. So for now, it'll just close the warning message right away