### PR TITLE
[update]Preload update

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,7 @@ if (window.CanvasRenderingContext2D) {
   if (state.advanced.preloadWorker && state.advanced.engineType === engineTypes.PDFNETJS) {
     if (state.document.pdfType !== 'wait') {
       getBackendPromise(state.document.pdfType).then(pdfType => {
-        window.CoreControls.preloadPDFWorker(pdfType, {}, {});
+        window.CoreControls.initPDFWorkerTransports(pdfType, {}, null);
       });
     }
 


### PR DESCRIPTION
Use 'initPDFWorkerTransports' instead of 'preloadPDFWorker' so that the 'pdfnet.res' file get loaded. 'initPDFWorkerTransports' actually calls 'preloadPDFWorker' if it hadn't been called yet so this should be safe. 