### PR TITLE
[bugfix] Fixed issue where overlays use getOverlayPositionBasedOn wil…

### DIFF
--- a/src/components/SignatureOverlay/SignatureOverlay.js
+++ b/src/components/SignatureOverlay/SignatureOverlay.js
@@ -82,7 +82,7 @@ class SignatureOverlay extends React.PureComponent {
     const { left, right } = getOverlayPositionBasedOn('signatureToolButton', this.overlay);
     this.setState({ 
       // TODO: remove the hard-coded value. 
-      left: left === 0 ? window.innerWidth / 2 - 95 : left - 95,
+      left: left === -9999 ? window.innerWidth / 2 - 95 : left - 95,
       right 
     });
   }

--- a/src/helpers/getOverlayPositionBasedOn.js
+++ b/src/helpers/getOverlayPositionBasedOn.js
@@ -3,10 +3,11 @@ export default (element, overlay, align = 'left') => {
   let left = 0;
   let right = 'auto';
 
-  // By default the button will be in the header
-  // but a user can disable it by calling viewerInstance.actions.disableElement(...);
+  // by default the button is visible in the header
+  // but it can be removed from the DOM by calling viewerInstance.disableElement(...);
+  // in this case we are not able to position the overlay correctly so we just "hide" the overlay 
   if (!button) {
-    return { left, right };
+    return { left: -9999, right };
   }
 
   const { left: buttonLeft, right: buttonRight, width: buttonWidth } = button.getBoundingClientRect();


### PR DESCRIPTION
…l position to left top 0 when it can't find the button to position itself.

This is a workaround, I can think about other two options but I'm not sure if they are better:

1. if the button is not in DOM, then we return undefined or an empty object and in each overlay component we check the return value and close it
2. getOverlayPositionBasedOn takes another argument which is a callback that will be invoked when the button is not in the DOM