### PR TITLE
[bugfix] Fix annotation and rotation bugs for thumbnails

### DIFF
--- a/src/components/Thumbnail/Thumbnail.js
+++ b/src/components/Thumbnail/Thumbnail.js
@@ -18,18 +18,21 @@ class Thumbnail extends React.PureComponent {
     onLoad: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired,
     onRemove: PropTypes.func.isRequired,
+    updateAnnotations: PropTypes.func,
     closeElement: PropTypes.func.isRequired,
   }
 
   constructor(props) {
     super(props);
     this.thumbContainer = React.createRef();
+    this.onLayoutChangedHandler = this.onLayoutChanged.bind(this);
   }
 
   componentDidMount() {
     const { onLoad, index } = this.props;
 
     onLoad(index, this.thumbContainer.current);
+    core.addEventListener('layoutChanged', this.onLayoutChangedHandler);
   }
 
   componentDidUpdate(prevProps) {
@@ -45,8 +48,30 @@ class Thumbnail extends React.PureComponent {
 
   componentWillUnmount() {
     const { onRemove, index } = this.props;
-    
+    core.removeEventListener('layoutChanged', this.onLayoutChangedHandler);
     onRemove(index);
+  }
+
+  onLayoutChanged(e, changes) {
+    const { contentChanged } = changes;
+    const { index } = this.props;
+
+    const currentPage = index + 1;
+    const didLayoutChange = contentChanged.some(changedPage => currentPage + '' === changedPage);
+
+    if(didLayoutChange) {
+      const { thumbContainer } = this;
+      const { current } = thumbContainer;
+
+      core.loadThumbnailAsync(index, thumb => {
+        thumb.className = 'page-image';
+        current.removeChild(current.querySelector('.page-image'));
+        current.appendChild(thumb);
+        if (this.props.updateAnnotations) {
+          this.props.updateAnnotations(index, thumb);
+        }
+      });
+    }
   }
 
   handleClick = () => {

--- a/src/components/Thumbnail/Thumbnail.scss
+++ b/src/components/Thumbnail/Thumbnail.scss
@@ -20,9 +20,12 @@
     cursor: pointer;
 
     .page-image {
-      width: auto !important;
+      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+        /* only for IE*/
+        height: auto !important;
+        width: auto !important;
+      }
       max-width: 148px;
-      height: auto !important;
       max-height: 148px;
       border: 1px solid transparent;
     }

--- a/src/components/ThumbnailsPanel/ThumbnailsPanel.js
+++ b/src/components/ThumbnailsPanel/ThumbnailsPanel.js
@@ -186,6 +186,7 @@ class ThumbnailsPanel extends React.PureComponent {
         if (this.thumbs[pageIndex]) {
           this.thumbs[pageIndex].element.appendChild(thumb);
           this.thumbs[pageIndex].loaded = true;
+          this.thumbs[pageIndex].updateAnnotationHandler = this.updateAnnotations.bind(this);
           this.removeFromPendingThumbs(pageIndex);
           this.updateAnnotations(pageIndex);
         }
@@ -234,13 +235,15 @@ class ThumbnailsPanel extends React.PureComponent {
 
   renderThumbnails = rowIndex => {
     const { numberOfColumns, canLoad } = this.state;
+    const { thumbs } = this;
 
     return (
       <div className="row" key={rowIndex}>
         {
           new Array(numberOfColumns).fill().map((_, columnIndex) => {
             const index = rowIndex * numberOfColumns + columnIndex;
-            
+            const updateHandler = thumbs && thumbs[index] ? thumbs[index].updateAnnotationHandler : null;
+
             return (
               index < this.props.totalPages 
               ? <Thumbnail
@@ -250,6 +253,7 @@ class ThumbnailsPanel extends React.PureComponent {
                   onLoad={this.onLoad}
                   onCancel={this.onCancel}
                   onRemove={this.onRemove}
+                  updateAnnotations={updateHandler}
                 />
               : null
             );


### PR DESCRIPTION
This pull request is for fixing two thumbnails bugs. They are:

**annotation canvas being bigger then page canvas**
![image](https://user-images.githubusercontent.com/45575633/55117453-219a5100-50a8-11e9-850d-ba222f0fd044.png)
Steps to reproduces: 
  - Set the browser zoom to less then 100% and load a viewer
  - Open a pdf (not xod or office file, thumbnails would be an IMG instead of an canvas)
  - Annotation canvas would be larger then page canvas so any annotation on it would be off

Solutions:  Removing the 'width/height: auto !important;' in the css fix this issue. Only problem is 'auto !important' is needed for xod files in IE (why I have a media query that only affect IE, this problem still exists in IE).

**Rotating the document data doesn't rotate the thumbnail**
(this bug was reported in #143)

If the users run something like 'readerControl.docViewer.getDocument().rotatePages([1], 1)' the document data and viewer get changed but the thumbnail doesn't. I updated the thumbnail to reload on 'layoutChange' so the thumbnails matches the actual data.
