### PR TITLE
[bugfix] Fix issue where the tools overlay position is wrong if users…

### DIFF
--- a/src/components/ToolsOverlay/ToolsOverlay.js
+++ b/src/components/ToolsOverlay/ToolsOverlay.js
@@ -36,6 +36,13 @@ class ToolsOverlay extends React.PureComponent {
 
   componentDidMount() {
     window.addEventListener('resize', this.handleWindowResize);
+
+    // this component can be opened before mounting to the DOM if users call the setToolMode API
+    // in this case we need to set its position immediately after it's mounted 
+    // otherwise its left is 0 instead of left-aligned with the tool group button
+    if (this.props.isOpen) {
+      this.setOverlayPosition();
+    }
   }
 
   componentDidUpdate(prevProps) {


### PR DESCRIPTION
… call setToolMode API in the ready event.

Actually this issue also happens to other overlay components and to fix the issue we need to duplicate logic since we don't have a "base" component to handle this logic.

To reproduce the issue for the ViewControlsOverlay component, add `readerControl.openElement('viewControlsOverlay')` under `$(document).trigger('viewerLoaded');` in index.js. After the app renders you can see that the component is open and it's in the wrong position.