### PR TITLE
[bugfix] Fix issue where clicking on Marquee Zoom doesn't change the …

### DIFF
--- a/assets/ic-triangle.svg
+++ b/assets/ic-triangle.svg
@@ -3,7 +3,7 @@
     <!-- Generator: Sketch 52.6 (67491) - http://www.bohemiancoding.com/sketch -->
     <title>Triangle</title>
     <desc>Created with Sketch.</desc>
-    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" fill-opacity="0.54">
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
         <g id="Artboard" transform="translate(0.000000, -3.000000)" fill="#000000">
             <polygon id="Triangle" transform="translate(12.000000, 12.000000) scale(1, -1) translate(-12.000000, -12.000000) " points="12 3 24 21 0 21"></polygon>
         </g>

--- a/src/components/Icon/Icon.scss
+++ b/src/components/Icon/Icon.scss
@@ -12,10 +12,8 @@
     height: 18px;
   }
 
-  path:not([fill=none]) {
-    fill: currentColor;
-  }
-  polygon:not([fill=none]) {
+  path:not([fill=none]),
+  polygon#Triangle {
     fill: currentColor;
   }
 }

--- a/src/components/ToggleElementOverlay/ToggleElementOverlay.scss
+++ b/src/components/ToggleElementOverlay/ToggleElementOverlay.scss
@@ -47,7 +47,7 @@
   display: flex;
   z-index: 1;
   background-color: inherit;
-  &:hover + .OverlayButton{
+  &:hover + .OverlayButton {
     background-color:inherit;
   }
 }

--- a/src/components/ZoomOverlay/ZoomOverlay.js
+++ b/src/components/ZoomOverlay/ZoomOverlay.js
@@ -94,9 +94,7 @@ class ZoomOverlay extends React.PureComponent {
           />
         )}
         <div className="spacer" />
-        {
-          this.props.isMarqueeZoomToolDisabled ? false : <OverlayItem  onClick={() => closeElements(['zoomOverlay'])} buttonName={t('tool.Marquee')} />
-        }
+        <ToolButton toolName="MarqueeZoomTool" label={t('tool.Marquee')} onClick={() => closeElements(['zoomOverlay'])} />
       </div>
     );
   }

--- a/src/components/ZoomOverlay/ZoomOverlay.scss
+++ b/src/components/ZoomOverlay/ZoomOverlay.scss
@@ -22,7 +22,8 @@
   }
   
   .ToolButton {
-    background: white;
+    background-color: #FFFFFF;
+    background-color: var(--primary-color);
     height: 35px;
     font-family: 'Roboto', sans-serif;
 


### PR DESCRIPTION
…tool mode. Use a css selector other than polygon:not([fill=none]) in Icon.scss because this will fill the measurement tool icons to be a square