### PR TITLE
[Bugfix] Fix redaction style

### DIFF
--- a/src/components/RedactionOverlay/RedactionOverlay.scss
+++ b/src/components/RedactionOverlay/RedactionOverlay.scss
@@ -15,6 +15,12 @@
   }
 }
 
+.redactHeader{
+  svg{
+    fill: #757575;
+  }
+}
+
 .RedactionOverlay {
   @extend %overlay;
 

--- a/src/components/RedactionOverlay/RedactionOverlay.scss
+++ b/src/components/RedactionOverlay/RedactionOverlay.scss
@@ -1,5 +1,6 @@
 @import '../../constants/styles';
 @import '../../constants/overlay';
+@import '../../components/Icon/Icon.scss';
 
 .redactHeader:after{
   content: '';
@@ -16,8 +17,9 @@
 }
 
 .redactHeader{
-  svg{
+  .Icon{
     fill: #757575;
+    fill: var(--icon-color);
   }
 }
 

--- a/src/components/RedactionOverlay/RedactionOverlay.scss
+++ b/src/components/RedactionOverlay/RedactionOverlay.scss
@@ -16,9 +16,18 @@
 }
 
 .redactHeader{
-  .Icon{
-    fill: #757575;
-    fill: var(--icon-color);
+  &.inactive{
+    .Icon{
+      fill: #757575;
+      fill: var(--icon-color);
+    }
+  }
+
+  &.active{
+    .Icon{
+      fill: #757575;
+      fill: var(--icon-active-color);
+    }
   }
 }
 
@@ -54,4 +63,20 @@
       flex: 1;
       height: 100%;
   }}
+
+  .Button{
+    &.inactive{
+      .Icon{
+        fill: #757575;
+        fill: var(--icon-color);
+      }
+    }
+  
+    &.active{
+      .Icon{
+        fill: #757575;
+        fill: var(--icon-active-color);
+      }
+    }
+  }
 }

--- a/src/components/RedactionOverlay/RedactionOverlay.scss
+++ b/src/components/RedactionOverlay/RedactionOverlay.scss
@@ -1,6 +1,5 @@
 @import '../../constants/styles';
 @import '../../constants/overlay';
-@import '../../components/Icon/Icon.scss';
 
 .redactHeader:after{
   content: '';


### PR DESCRIPTION
Small fix for the redaction icon. The inside "lines" weren't being set to the same style as the other lines
![image](https://user-images.githubusercontent.com/45575633/56068256-04fe4a00-5d33-11e9-9a24-b7593f4b692a.png)

Another fix would be update "Icon.scss" to set all fill to be whatever 'var(--icon-color)' is