### PR TITLE
[bugfix] Fix issue where annotation popup will open and then close im…

### DIFF
--- a/src/components/NotesPanel/NotesPanel.js
+++ b/src/components/NotesPanel/NotesPanel.js
@@ -198,7 +198,13 @@ class NotesPanel extends React.PureComponent {
     }
 
     return (
-      <div className="Panel NotesPanel" style={{ display }} data-element="notesPanel" onClick={() => core.deselectAllAnnotations()}>
+      <div
+        className="Panel NotesPanel"
+        style={{ display }}
+        data-element="notesPanel"
+        onClick={core.deselectAllAnnotations}
+        onScroll={e => e.stopPropagation()}
+      >
         {this.rootAnnotations.length === 0 
         ? <div className="no-annotations">{t('message.noAnnotations')}</div>
         : <React.Fragment>


### PR DESCRIPTION
…mediately when selected if there are many annotations in the document due to the scroll event triggered by scrollIntoView