### PR TITLE
Basic error modal API

### DIFF
--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -73,6 +73,7 @@ import updateOutlines from './updateOutlines';
 import updateTool from './updateTool';
 import print from './print';
 import showWarningMessage from './showWarningMessage';
+import showErrorMessage from './showErrorMessage';
 import enableRedaction from './enableRedaction';
 import disableRedaction from './disableRedaction';
 import enableLocalStorage from './enableLocalStorage';
@@ -157,6 +158,7 @@ export default {
   setMaxZoomLevel,
   setMinZoomLevel,
   showWarningMessage,
+  showErrorMessage,
   enableRedaction,
   disableRedaction,
   enableLocalStorage,

--- a/src/apis/showErrorMessage.js
+++ b/src/apis/showErrorMessage.js
@@ -1,0 +1,5 @@
+import fireEvent from '../helpers/fireEvent';
+
+export default message => {
+  fireEvent('customErrorMessage', message);
+};

--- a/src/components/ErrorModal/ErrorModal.js
+++ b/src/components/ErrorModal/ErrorModal.js
@@ -25,6 +25,7 @@ class ErrorModal extends React.PureComponent {
 
   componentDidMount() {
     window.addEventListener('loaderror', this.onError);
+    window.addEventListener('customErrorMessage', this.onError);
   }
 
   componentDidUpdate(prevProps) {
@@ -35,6 +36,7 @@ class ErrorModal extends React.PureComponent {
 
   componentWillUnmount() {
     window.removeEventListener('loaderror', this.onError);
+    window.removeEventListener('customErrorMessage', this.onError);
   }
 
   onError = error => {

--- a/src/components/ErrorModal/ErrorModal.js
+++ b/src/components/ErrorModal/ErrorModal.js
@@ -45,12 +45,15 @@ class ErrorModal extends React.PureComponent {
     openElement('errorModal');
 
     let errorMessage = '' + (error.detail || error.message);
-    if (errorMessage.indexOf('File does not exist') > -1) {
-      errorMessage = t('message.notSupported');
-    }
-    if (documentPath.indexOf('file:///') > -1) {
-      console.error(`WebViewer doesn't have access to file URLs because of browser security restrictions. Please see https://www.pdftron.com/documentation/web/guides/basics/troubleshooting-document-loading#not-allowed-to-load-local-resource:-file:`);
-    }
+    
+    if (error.type === 'loaderror') {
+      if (errorMessage.indexOf('File does not exist') > -1) {
+        errorMessage = t('message.notSupported');
+      }
+      if (documentPath.indexOf('file:///') > -1) {
+        console.error(`WebViewer doesn't have access to file URLs because of browser security restrictions. Please see https://www.pdftron.com/documentation/web/guides/basics/troubleshooting-document-loading#not-allowed-to-load-local-resource:-file:`);
+      }
+    }  
 
     this.setState({ errorMessage });
   }

--- a/src/index.js
+++ b/src/index.js
@@ -219,6 +219,7 @@ if (window.CanvasRenderingContext2D) {
           setToolMode: apis.setToolMode(store),
           setZoomLevel: apis.setZoomLevel,
           showWarningMessage: apis.showWarningMessage(store),
+          showErrorMessage: apis.showErrorMessage,
           toggleFullScreen: apis.toggleFullScreen,
           unregisterTool: apis.unregisterTool(store),
           updateOutlines: apis.updateOutlines(store),


### PR DESCRIPTION
Triggers a 'customErrorMessage' event to get the error modal to display with the provided error message. This was to avoid other handlers of 'loaderror' to not trigger when there is no actual load error.