### PR TITLE
[update] update freetext element to have a transparent outline instea…

### DIFF
--- a/src/components/DocumentContainer/DocumentContainer.scss
+++ b/src/components/DocumentContainer/DocumentContainer.scss
@@ -78,7 +78,7 @@
       padding: 0;
       box-sizing: border-box;
       resize: none;
-      outline: none;
+      outline: 1px solid transparent;
     }
   }
 }


### PR DESCRIPTION
…d of none. In iOS if a textarea has border:none, transparent background and outline:none then the text becomes invisible when typing from 'scratch'. I'm not sure what's the best way to solve this issue but this is one option