### PR TITLE
[bugfix] changed error modal API to use redux instead of events

### DIFF
--- a/src/apis/showErrorMessage.js
+++ b/src/apis/showErrorMessage.js
@@ -1,5 +1,5 @@
 import actions from 'actions';
 
 export default store => message => {
-  store.dispatch(actions.setErrorMessage(message));
+  store.dispatch(actions.showErrorMessage(message));
 };

--- a/src/apis/showErrorMessage.js
+++ b/src/apis/showErrorMessage.js
@@ -1,5 +1,5 @@
-import fireEvent from '../helpers/fireEvent';
+import actions from 'actions';
 
-export default message => {
-  fireEvent('customErrorMessage', message);
+export default store => message => {
+  store.dispatch(actions.setErrorMessage(message));
 };

--- a/src/components/ErrorModal/ErrorModal.js
+++ b/src/components/ErrorModal/ErrorModal.js
@@ -19,13 +19,8 @@ class ErrorModal extends React.PureComponent {
     t: PropTypes.func.isRequired
   }
 
-  state = {
-    errorMessage: ''
-  }
-
   componentDidMount() {
     window.addEventListener('loaderror', this.onError);
-    window.addEventListener('customErrorMessage', this.onError);
   }
 
   componentDidUpdate(prevProps) {
@@ -36,7 +31,6 @@ class ErrorModal extends React.PureComponent {
 
   componentWillUnmount() {
     window.removeEventListener('loaderror', this.onError);
-    window.removeEventListener('customErrorMessage', this.onError);
   }
 
   onError = error => {
@@ -53,9 +47,9 @@ class ErrorModal extends React.PureComponent {
       if (documentPath.indexOf('file:///') > -1) {
         console.error(`WebViewer doesn't have access to file URLs because of browser security restrictions. Please see https://www.pdftron.com/documentation/web/guides/basics/troubleshooting-document-loading#not-allowed-to-load-local-resource:-file:`);
       }
-    }  
+    }
 
-    this.setState({ errorMessage });
+    this.props.setErrorMessage(errorMessage);
   }
 
   render() {
@@ -63,26 +57,28 @@ class ErrorModal extends React.PureComponent {
       return null;
     }
 
-    const { errorMessage } = this.state;
+    const { message } = this.props;
     const className = getClassName('Modal ErrorModal', this.props);
 
     return (
       <div className={className} data-element="errorModal">
-        <div className="container">{errorMessage}</div>
+        <div className="container">{message}</div>
       </div>
     );
   }
 }
 
 const mapStateToProps = state => ({
+  message: selectors.getErrorMessage(state),
   isDisabled: selectors.isElementDisabled(state, 'errorModal'),
   isOpen: selectors.isElementOpen(state, 'errorModal'),
-  documentPath: selectors.getDocumentPath(state)
+  documentPath: selectors.getDocumentPath(state),
 });
 
 const mapDispatchToProps = {
   openElement: actions.openElement,
   closeElements: actions.closeElements,
+  setErrorMessage: actions.setErrorMessage,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(translate()(ErrorModal));

--- a/src/components/ErrorModal/ErrorModal.js
+++ b/src/components/ErrorModal/ErrorModal.js
@@ -78,7 +78,7 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = {
   openElement: actions.openElement,
   closeElements: actions.closeElements,
-  setErrorMessage: actions.setErrorMessage,
+  setErrorMessage: actions.showErrorMessage,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(translate()(ErrorModal));

--- a/src/index.js
+++ b/src/index.js
@@ -219,7 +219,7 @@ if (window.CanvasRenderingContext2D) {
           setToolMode: apis.setToolMode(store),
           setZoomLevel: apis.setZoomLevel,
           showWarningMessage: apis.showWarningMessage(store),
-          showErrorMessage: apis.showErrorMessage,
+          showErrorMessage: apis.showErrorMessage(store),
           toggleFullScreen: apis.toggleFullScreen,
           unregisterTool: apis.unregisterTool(store),
           updateOutlines: apis.updateOutlines(store),

--- a/src/redux/actions/exposedActions.js
+++ b/src/redux/actions/exposedActions.js
@@ -130,6 +130,10 @@ export const showWarningMessage = options => dispatch => {
   dispatch({ type: 'SET_WARNING_MESSAGE', payload: options });
   dispatch(openElement('warningModal'));
 };
+export const setErrorMessage = message => dispatch => {
+  dispatch({ type: 'SET_ERROR_MESSAGE', payload: { message } });
+  dispatch(openElement('errorModal'));
+};
 export const setCustomNoteFilter = filterFunc => ({ type: 'SET_CUSTOM_NOTE_FILTER', payload: { customNoteFilter: filterFunc } });
 export const setZoomList = zoomList => dispatch => {
   const minZoomLevel = getMinZoomLevel();

--- a/src/redux/actions/exposedActions.js
+++ b/src/redux/actions/exposedActions.js
@@ -130,7 +130,7 @@ export const showWarningMessage = options => dispatch => {
   dispatch({ type: 'SET_WARNING_MESSAGE', payload: options });
   dispatch(openElement('warningModal'));
 };
-export const setErrorMessage = message => dispatch => {
+export const showErrorMessage = message => dispatch => {
   dispatch({ type: 'SET_ERROR_MESSAGE', payload: { message } });
   dispatch(openElement('errorModal'));
 };

--- a/src/redux/reducers/viewerReducer.js
+++ b/src/redux/reducers/viewerReducer.js
@@ -149,7 +149,9 @@ export default initialState => (state = initialState, action) => {
     case 'SET_SWIPE_ORIENTATION':
       return { ...state, swipeOrientation: payload.swipeOrientation };
     case 'SET_WARNING_MESSAGE':
-      return { ...state, warning: payload};
+      return { ...state, warning: payload };
+    case 'SET_ERROR_MESSAGE':
+      return { ...state, errorMessage: payload.message };
     case 'SET_CUSTOM_NOTE_FILTER':
       return { ...state, customNoteFilter: payload.customNoteFilter };
     case 'SET_ZOOM_LIST':

--- a/src/redux/selectors/exposedSelectors.js
+++ b/src/redux/selectors/exposedSelectors.js
@@ -87,6 +87,10 @@ export const getWarningConfirmEvent = state => state.viewer.warning && state.vie
 export const getWarningConfirmBtnText = state =>  state.viewer.warning && state.viewer.warning.confirmBtnText;
 export const getWarningCancelEvent = state =>  state.viewer.warning && state.viewer.warning.onCancel;
 
+
+// error message
+export const getErrorMessage = state => state.viewer.errorMessage || '';
+
 // document
 export const getDocument = state => state.document;
 export const getDocumentId = state => state.document.id;


### PR DESCRIPTION
Fixed issue where the API is called before the component was able to mount. Now the modal depends on redux to get the error message. Previous implementation still works but instead of setting local state, the redux state is updated instead.