### PR TITLE
[bugfix] fixed issue with enabling & disabling the signature modal

### DIFF
--- a/src/components/SignatureModal/SignatureModal.js
+++ b/src/components/SignatureModal/SignatureModal.js
@@ -44,7 +44,6 @@ class SignatureModal extends React.PureComponent {
 
   componentDidUpdate(prevProps) {
     if (prevProps.isDisabled && !this.props.isDisabled && !this.isCanvasReady) {
-      console.log('triggered')
       this.setUpSignatureCanvas();
     }
 

--- a/src/components/SignatureModal/SignatureModal.js
+++ b/src/components/SignatureModal/SignatureModal.js
@@ -43,6 +43,10 @@ class SignatureModal extends React.PureComponent {
   }
 
   componentDidUpdate(prevProps) {
+    if (prevProps.isDisabled && !this.props.isDisabled) {
+      this.setUpSignatureCanvas();
+    }
+
     if (!prevProps.isOpen && this.props.isOpen) {
       core.setToolMode('AnnotationCreateSignature');
       this.setState(this.initialState);
@@ -59,6 +63,9 @@ class SignatureModal extends React.PureComponent {
 
   setUpSignatureCanvas = () => {
     const canvas = this.canvas.current;
+    if (!this.canvas.current) {
+      return;
+    }
     this.signatureTool.setSignatureCanvas($(canvas));
     // draw nothing in the background since we want to convert the signature on the canvas
     // to an image and we don't want the background to be in the image.

--- a/src/components/SignatureModal/SignatureModal.js
+++ b/src/components/SignatureModal/SignatureModal.js
@@ -43,7 +43,8 @@ class SignatureModal extends React.PureComponent {
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps.isDisabled && !this.props.isDisabled) {
+    if (prevProps.isDisabled && !this.props.isDisabled && !this.isCanvasReady) {
+      console.log('triggered')
       this.setUpSignatureCanvas();
     }
 
@@ -76,6 +77,7 @@ class SignatureModal extends React.PureComponent {
     canvas.addEventListener('mouseup', this.handleFinishDrawing);
     canvas.addEventListener('touchend', this.handleFinishDrawing);
     this.setSignatureCanvasSize();
+    this.isCanvasReady = true;
   }
 
   setSignatureCanvasSize = () => {


### PR DESCRIPTION
If the signature modal is disabled to start, the signature canvas is never setup due to the canvas reference never being set. Enabling the modal afterwards also gives an error since the signature tool was not initialized.

The solution to the missing canvas was to ensure that the initial setup of the signature canvas is skipped if the canvas did not render. The solution to enabling an initially disabled signature modal was to perform the setup if the modal was enabled and setup hasn't been performed at least once.