### PR TITLE
[update] Sets default icon of group button to last used tool button

### DIFF
--- a/src/components/GroupButton/GroupButton.js
+++ b/src/components/GroupButton/GroupButton.js
@@ -98,7 +98,6 @@ class GroupButton extends React.PureComponent {
     }
     const { toolName } = this.state;
     const activeIcon = children.find(button => button.toolName === toolName) ? children.find(button => button.toolName === toolName).img: '';
-    // const img = this.props.img ? this.props.img : isOnlyTools ? activeIcon : '';
     const img = activeIcon ? activeIcon : '';
     let color;
     if (isActive && !this.props.img && iconColor && activeToolStyles[iconColor]) {

--- a/src/components/GroupButton/GroupButton.js
+++ b/src/components/GroupButton/GroupButton.js
@@ -98,7 +98,8 @@ class GroupButton extends React.PureComponent {
     }
     const { toolName } = this.state;
     const activeIcon = children.find(button => button.toolName === toolName) ? children.find(button => button.toolName === toolName).img: '';
-    const img = this.props.img ? this.props.img : isOnlyTools ? activeIcon : '';
+    // const img = this.props.img ? this.props.img : isOnlyTools ? activeIcon : '';
+    const img = activeIcon ? activeIcon : '';
     let color;
     if (isActive && !this.props.img && iconColor && activeToolStyles[iconColor]) {
       color = activeToolStyles[iconColor].toHexString();


### PR DESCRIPTION
Sets default icon of `GroupButton` to last used tool button if the group contains action buttons.