### PR TITLE
[update] Set default group button icon when img is unspecified and group contains buttons other than tool button

### DIFF
--- a/assets/ic_group_button_24px.svg
+++ b/assets/ic_group_button_24px.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M10 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2z"/><path d="M0 0h24v24H0z" fill="none"/></svg>

--- a/src/components/GroupButton/GroupButton.js
+++ b/src/components/GroupButton/GroupButton.js
@@ -93,12 +93,13 @@ class GroupButton extends React.PureComponent {
         return null;
       }
     }
-    if (!img && !isOnlyTools) {
-      console.warn('GroupButton contains buttons other than toolButtons and no img is found. Please specify an img');
+    if (!this.props.img && !isOnlyTools) {
+      console.warn('GroupButton containing buttons other than tool button requires img. Please specify an img for the group button.');
     }
     const { toolName } = this.state;
     const activeIcon = children.find(button => button.toolName === toolName) ? children.find(button => button.toolName === toolName).img: '';
-    const img = this.props.img ? this.props.img : isOnlyTools ? activeIcon : '';
+    const defaultGroupIcon = 'ic_group_button_24px'
+    const img = this.props.img ? this.props.img : isOnlyTools ? activeIcon : defaultGroupIcon;
     let color;
     if (isActive && !this.props.img && iconColor && activeToolStyles[iconColor]) {
       color = activeToolStyles[iconColor].toHexString();


### PR DESCRIPTION
Sets default group button icon to default group icon when `img` is unspecified and group contains buttons other than tool button. Also generates a warning message on the console. 