### PR TITLE
[bugfix] Fix for server URL with XOD

### DIFF
--- a/src/helpers/setupLoadAnnotationsFromServer.js
+++ b/src/helpers/setupLoadAnnotationsFromServer.js
@@ -15,6 +15,7 @@ export default store =>  {
 
     if (window.readerControl.serverFailed) {
       callback(originalData);
+      return;
     } else if (window.readerControl.loadedFromServer) {
       callback('');
       return;


### PR DESCRIPTION
The code in 'setupLoadAnnotationFromServer.js' is calling the callback function multiple times.  When it fails once, it calls the callback because of the "window.readerControl.serverFailed" being true and again below in the AJAX call. 

The problem is that in the core, "DocumenViewer.finishLoadingLastAnnotations" get called twice so it'll end up trying to load the next part of the file twice. This will fail for XOD files.