### PR TITLE
[Update] Merge in change for version checking

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,10 +29,7 @@ import setDefaultToolStyles from 'helpers/setDefaultToolStyles';
 import setUserPermission from 'helpers/setUserPermission';
 import rootReducer from 'reducers/rootReducer';
 
-const coreVersion = window.CoreControls.DocumentViewer.prototype.version.slice(0, -6);
-const uiVersion = require('../package.json').version;
-console.log(`[WebViewer] v${coreVersion} is running.`);
-
+const packageConfig = require('../package.json');
 const middleware = [thunk];
 
 if (process.env.NODE_ENV === 'development') {
@@ -115,6 +112,24 @@ if (window.CanvasRenderingContext2D) {
   }
 
   loadCustomCSS(state.advanced.customCSS);
+
+  const coreVersion = window.CoreControls.DocumentViewer.prototype.version;
+  const uiVersion = packageConfig.version;
+  
+  if (coreVersion && uiVersion) {
+    // we are using semantic versioning (ie ###.###.###) so the first number is the major version, follow by the minor version, and the patch number
+    const [ coreMajorVersion, coreMinorVersion ] = coreVersion.split('.');
+    const [ uiMajorVersion, uiMinorVersion ] = uiVersion.split('.');
+
+    // eslint-disable-next-line no-console
+    console.log(`[WebViewer] WebViewer UI version: ${uiVersion}, WebViewer Core version: ${coreVersion}`);
+
+    if (parseInt(coreMajorVersion) < parseInt(uiMajorVersion)) {
+      console.error(`[WebViewer] Version Mismatch: WebViewer UI requires Core version ${uiVersion} and above.`);
+    } else if(parseInt(coreMinorVersion) < parseInt(uiMinorVersion)) {
+      console.warn(`[WebViewer] Version Mismatch: WebViewer UI requires Core version ${uiVersion} and above.`);
+    }
+  }
 
   fullAPIReady.then(() => {
     return loadConfig();


### PR DESCRIPTION
Merge in changes from #271

Only different was I got rid of the 'version.slice(0, -6);' at the top

I was thinking of doing something like 
```
    const [ coreMajorVersion, coreMinorVersion,, coreCommitVersion ] = coreVersion.split('.');
    const [ uiMajorVersion, uiMinorVersion ] = uiVersion.split('.');

    if(coreCommitVersion) { // we don't want commit version anymore
      coreVersion = coreVersion.slice(0, -(coreCommitVersion.length + 1));
    }
```
Let me know if I should I add it