### PR TITLE
Performance update for hidden notes

### DIFF
--- a/src/components/NotesPanel/NotesPanel.js
+++ b/src/components/NotesPanel/NotesPanel.js
@@ -62,14 +62,15 @@ class NotesPanel extends React.PureComponent {
   }
 
   onAnnotationChanged = () => {
-    this.rootAnnotations = this.getRootAnnotations();  
+    this.rootAnnotations = this.getRootAnnotations();
     const notesToRender = this.filterAnnotations(this.rootAnnotations, this.state.searchInput);
-    
-    this.setVisibleNoteIds(notesToRender);
+    const visibleNotes = notesToRender.filter(a => !a.Hidden);
+
+    this.setVisibleNoteIds(visibleNotes);
     this.setState({ notesToRender });
   }
 
-  getRootAnnotations = () => core.getAnnotationsList().filter(annotation => annotation.Listable && !annotation.isReply() && !annotation.Hidden);
+  getRootAnnotations = () => core.getAnnotationsList().filter(annotation => annotation.Listable && !annotation.isReply());
 
   handleInputChange = e => {
     const searchInput = e.target.value;


### PR DESCRIPTION
Changed notes panel to render hidden annotations as real, hidden note components. This should reduce the performance hit when hiding and unhiding a bunch of annotations. The issue impacts FireFox (~6s), Edge (a long time), IE (a long time), and Safari (~2s).

Fixes #264

Before
![before](https://user-images.githubusercontent.com/25498512/58655805-d4b53f80-82cf-11e9-86d1-864a039d3295.gif)

After
![after](https://user-images.githubusercontent.com/25498512/58655823-dc74e400-82cf-11e9-8084-2dd049be12fc.gif)
