### PR TITLE
Update thumbnails when annotation visibility toggled

### DIFF
--- a/src/components/ThumbnailsPanel/ThumbnailsPanel.js
+++ b/src/components/ThumbnailsPanel/ThumbnailsPanel.js
@@ -31,6 +31,7 @@ class ThumbnailsPanel extends React.PureComponent {
     core.addEventListener('beginRendering', this.onBeginRendering);
     core.addEventListener('finishedRendering', this.onFinishedRendering);
     core.addEventListener('annotationChanged', this.onAnnotationChanged);
+    core.addEventListener('annotationHidden', this.onAnnotationChanged);
     window.addEventListener('resize', this.onWindowResize);
   }
   
@@ -38,6 +39,7 @@ class ThumbnailsPanel extends React.PureComponent {
     core.removeEventListener('beginRendering', this.onBeginRendering);
     core.removeEventListener('finishedRendering', this.onFinishedRendering);
     core.removeEventListener('annotationChanged', this.onAnnotationChanged);
+    core.removeEventListener('annotationHidden', this.onAnnotationChanged);
     window.removeEventListener('resize', this.onWindowResize);
   }
 


### PR DESCRIPTION
Thumbnails were not updated when annotations were hidden or unhidden.