### PR TITLE
[bugfix] resolves #289

### DIFF
--- a/src/components/ToolStylePopup/ToolStylePopup.scss
+++ b/src/components/ToolStylePopup/ToolStylePopup.scss
@@ -6,5 +6,5 @@
   @extend %popup-mobile;
 
   position: absolute;
-  z-index: 60;
+  z-index: 85;
 }


### PR DESCRIPTION
Changed z-index of ToolStylePopup to match `overlay.scss` and prevent `leftPanel` from covering the popup. 