### PR TITLE
[bugfix]Fix 'disableElement' being used be with redaction

### DIFF
--- a/src/components/RedactionOverlay/RedactionOverlay.js
+++ b/src/components/RedactionOverlay/RedactionOverlay.js
@@ -75,7 +75,7 @@ class RedactionOverlay extends React.PureComponent {
     return ( // TODO ask if there an easy way to keep the tool group as "redact"
       <div className={className} ref={this.overlay} style={{ left, right }} data-element="redactionOverlay" onMouseDown={e => e.stopPropagation()}>
         <ToolButton toolName="AnnotationCreateRedaction" />
-        { showApply && <Button className="ToolButton" dataElement="applyAllButton" title="action.applyAll" img="ic_check_black_24px" onClick={this.handleApplyButtonClick}/> }
+        { showApply && <ToolButton className="ToolButton" toolName="ApplyAllRedaction" dataElement="applyAllButton" title="action.applyAll" img="ic_check_black_24px" onClick={this.handleApplyButtonClick}/> }
 
         <div className="spacer hide-in-desktop"></div>
         <Button className="close hide-in-desktop" dataElement="toolsOverlayCloseButton" img="ic_check_black_24px" onClick={this.handleCloseClick} />

--- a/src/components/RedactionOverlay/RedactionOverlay.js
+++ b/src/components/RedactionOverlay/RedactionOverlay.js
@@ -76,7 +76,7 @@ class RedactionOverlay extends React.PureComponent {
     return ( // TODO ask if there an easy way to keep the tool group as "redact"
       <div className={className} ref={this.overlay} style={{ left, right }} data-element="redactionOverlay" onMouseDown={e => e.stopPropagation()}>
         <ToolButton toolName="AnnotationCreateRedaction" />
-        { showApply && <ActionButton className="ToolButton" toolName="ApplyAllRedaction" dataElement="applyAllButton" title="action.applyAll" img="ic_check_black_24px" onClick={this.handleApplyButtonClick}/> }
+        { showApply && <ActionButton dataElement="applyAllButton" title="action.applyAll" img="ic_check_black_24px" onClick={this.handleApplyButtonClick}/> }
 
         <div className="spacer hide-in-desktop"></div>
         <Button className="close hide-in-desktop" dataElement="toolsOverlayCloseButton" img="ic_check_black_24px" onClick={this.handleCloseClick} />

--- a/src/components/RedactionOverlay/RedactionOverlay.js
+++ b/src/components/RedactionOverlay/RedactionOverlay.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { translate } from 'react-i18next';
 
+import ActionButton from 'components/ActionButton';
 import ToolButton from 'components/ToolButton';
 import Button from 'components/Button';
 
@@ -75,7 +76,7 @@ class RedactionOverlay extends React.PureComponent {
     return ( // TODO ask if there an easy way to keep the tool group as "redact"
       <div className={className} ref={this.overlay} style={{ left, right }} data-element="redactionOverlay" onMouseDown={e => e.stopPropagation()}>
         <ToolButton toolName="AnnotationCreateRedaction" />
-        { showApply && <ToolButton className="ToolButton" toolName="ApplyAllRedaction" dataElement="applyAllButton" title="action.applyAll" img="ic_check_black_24px" onClick={this.handleApplyButtonClick}/> }
+        { showApply && <ActionButton className="ToolButton" toolName="ApplyAllRedaction" dataElement="applyAllButton" title="action.applyAll" img="ic_check_black_24px" onClick={this.handleApplyButtonClick}/> }
 
         <div className="spacer hide-in-desktop"></div>
         <Button className="close hide-in-desktop" dataElement="toolsOverlayCloseButton" img="ic_check_black_24px" onClick={this.handleCloseClick} />

--- a/src/redux/initialState.js
+++ b/src/redux/initialState.js
@@ -111,6 +111,7 @@ export default {
       AnnotationCreateSticky: { dataElement: 'stickyToolButton', title: 'annotation.stickyNote', img: 'ic_annotation_sticky_note_black_24px', showColor: 'active' },
       AnnotationCreateCallout: { dataElement: 'calloutToolButton', title: 'annotation.callout', img: 'ic_annotation_callout_black_24px', group: 'miscTools', showColor: 'active' },
       AnnotationCreateStamp: { dataElement: 'stampToolButton', title: 'annotation.stamp', img: 'ic_annotation_image_black_24px', group: 'miscTools', showColor: 'active' },
+      ApplyAllRedaction: { dataElement: 'applyAllButton', title: 'annotation.applyAll', img: 'ic_check_black_24px', group: 'measurementTools', showColor: 'active' },
       Pan: { dataElement: 'panToolButton', title: 'tool.pan', img: 'ic_pan_black_24px', showColor: 'never' },
       AnnotationEdit: { dataElement: 'selectToolButton', title: 'tool.select', img: 'ic_select_black_24px', showColor: 'never' },
       TextSelect: { dataElement: 'textSelectButton', title: 'tool.select', img: 'textselect_cursor', showColor: 'never' },

--- a/src/redux/initialState.js
+++ b/src/redux/initialState.js
@@ -111,7 +111,6 @@ export default {
       AnnotationCreateSticky: { dataElement: 'stickyToolButton', title: 'annotation.stickyNote', img: 'ic_annotation_sticky_note_black_24px', showColor: 'active' },
       AnnotationCreateCallout: { dataElement: 'calloutToolButton', title: 'annotation.callout', img: 'ic_annotation_callout_black_24px', group: 'miscTools', showColor: 'active' },
       AnnotationCreateStamp: { dataElement: 'stampToolButton', title: 'annotation.stamp', img: 'ic_annotation_image_black_24px', group: 'miscTools', showColor: 'active' },
-      ApplyAllRedaction: { dataElement: 'applyAllButton', title: 'annotation.applyAll', img: 'ic_check_black_24px', group: 'measurementTools', showColor: 'active' },
       Pan: { dataElement: 'panToolButton', title: 'tool.pan', img: 'ic_pan_black_24px', showColor: 'never' },
       AnnotationEdit: { dataElement: 'selectToolButton', title: 'tool.select', img: 'ic_select_black_24px', showColor: 'never' },
       TextSelect: { dataElement: 'textSelectButton', title: 'tool.select', img: 'textselect_cursor', showColor: 'never' },


### PR DESCRIPTION
Before  `readerControl.disableElement('applyAllButton')` didn't work. At some point, I'm going to remove 'RedactionOverlay.js' and make it like the other headers (wasn't possible before but it is now).