### PR TITLE
Fix how searching case sensitively is displayed in German ui

### DIFF
--- a/i18n/translation-de.json
+++ b/i18n/translation-de.json
@@ -137,7 +137,7 @@
       "warningPopupTitle": "Schwärzung anwenden"
     },
     "searchPanel": {
-      "caseSensitive": "Groß-/Kleinschreibung beachten",
+      "caseSensitive": "Groß-/Klein- schreibung beachten",
       "wholeWordOnly": "Ganzes Wort"
     },
     "signatureOverlay": {


### PR DESCRIPTION
With your translation it looks like this:

![d1WPymQMQzeTZ6k6](https://user-images.githubusercontent.com/7103208/60800796-17432500-a176-11e9-98c1-e36f080c68e2.jpg)

After the changes it looks like this.
![FLFH56bNNq9QlYIm](https://user-images.githubusercontent.com/7103208/60800800-19a57f00-a176-11e9-835d-bade5a43e855.jpeg)

I am German so, I hope you trust me with the syllable division ;-)