### PR TITLE
Fixed error using shortcut key while signature tool is disabled

### DIFF
--- a/src/event-listeners/onKeyDown.js
+++ b/src/event-listeners/onKeyDown.js
@@ -117,7 +117,10 @@ export default store => e => {
         } else if (e.key === 'r' || e.which === 82) { // (R)
           setToolModeAndGroup(dispatch, 'AnnotationCreateRectangle', 'shapeTools');
         } else if (e.key === 's' || e.which === 83) { // (S)
-          document.querySelector('[data-element="signatureToolButton"]').click();
+          const sigToolButton = document.querySelector('[data-element="signatureToolButton"]');
+          if (sigToolButton) {
+            sigToolButton.click();
+          }
         } else if (e.key === 't' || e.which === 84) { // (T)
           setToolModeAndGroup(dispatch, 'AnnotationCreateFreeText', '');
         } else if (e.key === 'u' || e.which === 85) { // (U)


### PR DESCRIPTION
Disabling the signature tool and pressing the shortcut key generates an error. Added a check to ensure the data element exists before attempting to trigger the tool.