### PR TITLE
[Bugfix]Fix highlighted text when using dark theme

### DIFF
--- a/src/apis/setTheme.js
+++ b/src/apis/setTheme.js
@@ -80,7 +80,6 @@ const setPresetTheme = theme => {
       buttonHover: '#F6F6F6',
       buttonActive: '#F0F0F0',
       text: '#333333',
-      textHighlighted: '#333333',
       icon: '#757575',
       iconActive: '#757575'
     },
@@ -91,7 +90,6 @@ const setPresetTheme = theme => {
       buttonHover: '#686880',
       buttonActive: '#686880',
       text: '#FFFFFF',
-      textHighlighted: '#333333',
       icon: '#FFFFFF',
       iconActive: '#FFFFFF'
     }
@@ -113,7 +111,6 @@ const setTheme = theme => {
     buttonHover: '--button-hover-color',
     buttonActive: '--button-active-color',
     text: '--text-color',
-    textHighlighted: '--text-highlighted-color',
     icon: '--icon-color',
     iconActive: '--icon-active-color'
   };

--- a/src/components/NoteContent/NoteContent.scss
+++ b/src/components/NoteContent/NoteContent.scss
@@ -90,7 +90,7 @@
   
       .highlight {
         background: #fffc95;
-        color: var(--text-highlighted-color);
+        color: #333333;
       }
     }
   }

--- a/src/components/SearchResult/SearchResult.scss
+++ b/src/components/SearchResult/SearchResult.scss
@@ -13,7 +13,7 @@
 
   &.selected {
     background: $gray10;
-    color: var(--text-highlighted-color);
+    color: #333333;
 
     .search-value {
       background: #fbcd9f;
@@ -22,6 +22,6 @@
 
   .search-value {
     background: #fffc95;
-    color: var(--text-highlighted-color);
+    color: #333333;
   }
 }


### PR DESCRIPTION
Highlighted text is hard to see when using dark theme, I updated it so it'll be black

![image](https://user-images.githubusercontent.com/45575633/63714885-87c20600-c7f7-11e9-8a9c-4e76dd08d9fa.png)
