### PR TITLE
[Bugfix] Fix problem with "goToNextPage" and "goToPrevPage" when showing more then one page

### DIFF
--- a/src/apis/goToNextPage.js
+++ b/src/apis/goToNextPage.js
@@ -32,11 +32,20 @@ import selectors from 'selectors';
 export default store => () => {
   const state = store.getState();
   const currentPage = selectors.getCurrentPage(state);
+  const totalPages = selectors.getTotalPages(state);
 
-  if (currentPage === selectors.getTotalPages(state)) {
+  const DisplayModes = window.CoreControls.DisplayModes;
+  const currentDisplayMode = window.readerControl.getLayoutMode();
+  let pageIncrease = 1;
+  if (currentDisplayMode !== DisplayModes.Single
+    && currentDisplayMode !== DisplayModes.Continuous) {
+    pageIncrease = 2;
+  }
+
+  if (currentPage === totalPages) {
     console.warn('you are at the last page');
   } else {
-    const nextPage = currentPage + 1;
+    const nextPage = currentPage + pageIncrease > totalPages ? totalPages : currentPage + pageIncrease;
     core.setCurrentPage(nextPage);
   }
 };

--- a/src/apis/goToPrevPage.js
+++ b/src/apis/goToPrevPage.js
@@ -32,10 +32,18 @@ import selectors from 'selectors';
 export default store => () => {
   const currentPage = selectors.getCurrentPage(store.getState());
 
+  const DisplayModes = window.CoreControls.DisplayModes;
+  const currentDisplayMode = window.readerControl.getLayoutMode();
+  let pageDecrease = 1;
+  if (currentDisplayMode !== DisplayModes.Single
+    && currentDisplayMode !== DisplayModes.Continuous) {
+    pageDecrease = 2;
+  }
+
   if (currentPage === 1) {
     console.warn('You are at the first page');
   } else {
-    const prevPage = currentPage - 1;
+    const prevPage = currentPage - pageDecrease > 1 ? currentPage - pageDecrease : 1;
     core.setCurrentPage(prevPage);
   }
 };


### PR DESCRIPTION
Calling "goToPrevPage" or "goToNextPage" changes the current page by 1. This is a problem when showing two pages at once because it doesn't update the display pages.

Also, I noticed that sometimes it'll do the correct thing and change the page by 2 while other times it doesn't. This seems to be a bug

This might be a core change, current when you zoom in, it'll focus on the "next" or "prev" page. We might want to make it increment/decrement by 2 when it's zoom out while keeping the current behaviour it has now. 