### PR TITLE
[BugFix] Applied fix for tool groups being visible during readonly mode

### DIFF
--- a/src/components/ToolGroupButton/ToolGroupButton.js
+++ b/src/components/ToolGroupButton/ToolGroupButton.js
@@ -105,13 +105,10 @@ class ToolGroupButton extends React.PureComponent {
       dataElement,
       toolButtonObjects,
       isActive,
-      toolNames,
+      allButtonsInGroupDisabled,
       iconColor,
       title,
     } = this.props;
-    const allButtonsInGroupDisabled = toolNames.every(
-      toolName => core.getTool(toolName).disabled,
-    );
 
     const { toolName } = this.state;
     const img = this.props.img
@@ -148,6 +145,7 @@ const mapStateToProps = (state, ownProps) => ({
   activeToolName: selectors.getActiveToolName(state),
   toolNames: selectors.getToolNamesByGroup(state, ownProps.toolGroup),
   toolButtonObjects: selectors.getToolButtonObjects(state),
+  allButtonsInGroupDisabled: selectors.allButtonsInGroupDisabled(state, ownProps.toolGroup),
   iconColor: selectors.getIconColor(
     state,
     mapToolNameToKey(selectors.getActiveToolName(state)),

--- a/src/redux/selectors/exposedSelectors.js
+++ b/src/redux/selectors/exposedSelectors.js
@@ -11,6 +11,17 @@ export const isElementOpen = (state, dataElement) =>
   state.viewer.openElements[dataElement] &&
   !state.viewer.disabledElements[dataElement]?.disabled;
 
+export const allButtonsInGroupDisabled = (state, toolGroup) => {
+  const toolButtonObjects = getToolButtonObjects(state);
+  const dataElements = Object.values(toolButtonObjects)
+    .filter(({ group }) => group === toolGroup)
+    .map(({ dataElement }) => dataElement);
+
+  const result = dataElements.every(dataElement => isElementDisabled(state, dataElement));
+
+  return result;
+};
+
 export const isElementActive = (state, tool) => {
   const {
     viewer: {


### PR DESCRIPTION
While the code to disable tools works, the tool group buttons were not determining whether all the tools underneath them were all disabled properly.

This fix applies the fix from the dev branch: b10aa6d55587cd81c30edbc9e588198e4f0d733e.