### PR TITLE
[BugFix] fix for crash when noteReply is disabled and trying to write a comment

### DIFF
--- a/src/components/Note/Note.js
+++ b/src/components/Note/Note.js
@@ -115,9 +115,10 @@ const ReplyArea = ({ annotation }) => {
       isSelected &&
       !isContentEditable
     ) {
-      textareaRef.current.focus();
+      textareaRef.current?.focus();
     }
   }, [isContentEditable, isNoteEditingTriggeredByAnnotationPopup, isSelected]);
+
 
   const postReply = e => {
     // prevent the textarea from blurring out


### PR DESCRIPTION
fix for crash when noteReply is disabled and trying to write a comment