### PR TITLE
[Bugfix] Clear current highlight text when new search is invalid

### DIFF
--- a/src/components/SearchOverlay/SearchOverlay.js
+++ b/src/components/SearchOverlay/SearchOverlay.js
@@ -195,7 +195,10 @@ class SearchOverlay extends React.PureComponent {
         core.displaySearchResult(result);
         setActiveResult(result);
         this.runSearchListeners();
+      } else {
+        core.clearSearchResults();
       }
+
       if (isSearchDone) {
         core.getDocumentViewer().trigger('endOfDocumentResult', true);
       }


### PR DESCRIPTION
When you search for text that doesn't exist, it doesn't clear the current result

i.e. "Revision" stays highlighted even when searching for something that doesn't exists
![image](https://user-images.githubusercontent.com/45575633/66157162-06207d80-e5d8-11e9-80ee-d1686c80b3ac.png)
