### PR TITLE
[Bugfx] Fixed issue with document drifting around in IE and Edge

### DIFF
--- a/src/helpers/documentContainerHelper.js
+++ b/src/helpers/documentContainerHelper.js
@@ -14,7 +14,7 @@ export const updateContainerWidth = (prevProps, props, container) => {
   if (leftPanelClosed) {
     expandContainerWidthBy(leftPanelWidth, container);
     container.style.marginLeft = '0px';
-  }
+  } 
 
   const rightPanelClosed = prevProps.isRightPanelOpen && !props.isRightPanelOpen;
   if (rightPanelClosed) {
@@ -39,29 +39,36 @@ export const updateContainerWidth = (prevProps, props, container) => {
   }
 };
 
-const expandContainerWidthBy = (panelWidth, container) => {
+const getWidthAfterTransition = container => {
+  const oldTransition = container.style.transition;
+  container.style.transition = 'none';
   const containerWidth = parseInt(window.getComputedStyle(container).width, 10);
+  container.style.transition = oldTransition;
+
+  return containerWidth;
+};
+
+const expandContainerWidthBy = (panelWidth, container) => {
+  const containerWidth = getWidthAfterTransition(container);
 
   if (isIEEdge) {
     container.style.width = `${containerWidth + panelWidth}px`;
   }
 
   if (isIE11) {
-    const scrollBarWidth = 17;
-    container.style.width = `${containerWidth + panelWidth + scrollBarWidth}px`;
+    container.style.width = `${containerWidth + panelWidth}px`;
   }
 };
 
 const shrinkContainerWidthBy = (panelWidth, container) => {
-  const containerWidth = parseInt(window.getComputedStyle(container).width, 10);
+  const containerWidth = getWidthAfterTransition(container);
 
   if (isIEEdge) {
     container.style.width = `${containerWidth - panelWidth}px`;
   }
 
   if (isIE11) {
-    const scrollBarWidth = 17;
-    container.style.width = `${containerWidth - panelWidth + scrollBarWidth}px`;
+    container.style.width = `${containerWidth - panelWidth}px`;
   }
 };
 

--- a/src/helpers/documentContainerHelper.js
+++ b/src/helpers/documentContainerHelper.js
@@ -14,7 +14,7 @@ export const updateContainerWidth = (prevProps, props, container) => {
   if (leftPanelClosed) {
     expandContainerWidthBy(leftPanelWidth, container);
     container.style.marginLeft = '0px';
-  } 
+  }
 
   const rightPanelClosed = prevProps.isRightPanelOpen && !props.isRightPanelOpen;
   if (rightPanelClosed) {

--- a/src/helpers/documentContainerHelper.js
+++ b/src/helpers/documentContainerHelper.js
@@ -56,7 +56,9 @@ const expandContainerWidthBy = (panelWidth, container) => {
   }
 
   if (isIE11) {
-    container.style.width = `${containerWidth + panelWidth}px`;
+    //need to add 'scrollBarWidth' or it breaks after "npm run build", this isn't needed for npm run start
+    const scrollBarWidth = 17;
+    container.style.width = `${containerWidth + panelWidth + scrollBarWidth}px`;
   }
 };
 
@@ -68,7 +70,8 @@ const shrinkContainerWidthBy = (panelWidth, container) => {
   }
 
   if (isIE11) {
-    container.style.width = `${containerWidth - panelWidth}px`;
+    const scrollBarWidth = 17;
+    container.style.width = `${containerWidth - panelWidth + scrollBarWidth}px`;
   }
 };
 


### PR DESCRIPTION
If a user clicks the top right note panel () or programmatically use "readerControl.setSideWindowVisibility()" quickly, the document with drift around.  You don't see this if you use it like a normal person

![20191016_DocumentDrifting](https://user-images.githubusercontent.com/45575633/66966578-91672d80-f032-11e9-9e02-c9c7285749ec.gif)

You can reproduce it here 
https://www.pdftron.com/samples/web/samples/viewing/viewing/
What it does depends on your zoom level and the size of the browser window. 

UPDATE: read below comment