### PR TITLE
[bugfix] fix worker loading after config.js is loaded

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -142,10 +142,6 @@ if (window.CanvasRenderingContext2D) {
       document.getElementById('app'),
     );
   });
-
-
-
-
 }
 
 window.addEventListener('hashchange', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -84,9 +84,9 @@ if (window.CanvasRenderingContext2D) {
   }
 
   const { preloadWorker } = state.advanced;
-  const { PDF, OFFICE, ALL } = workerTypes;
 
-  if (preloadWorker) {
+  function initTransports() {
+    const { PDF, OFFICE, ALL } = workerTypes;
     if (preloadWorker === PDF || preloadWorker === ALL) {
       getBackendPromise(state.document.pdfType).then(pdfType => {
         window.CoreControls.initPDFWorkerTransports(pdfType, {
@@ -108,11 +108,16 @@ if (window.CanvasRenderingContext2D) {
     }
   }
 
+
   loadCustomCSS(state.advanced.customCSS);
 
   logDebugInfo(state.advanced);
 
   fullAPIReady.then(() => loadConfig()).then(() => {
+    if (preloadWorker) {
+      initTransports();
+    }
+
     const { addEventHandlers, removeEventHandlers } = eventHandler(store);
     const docViewer = new window.CoreControls.DocumentViewer();
     window.docViewer = docViewer;
@@ -137,6 +142,10 @@ if (window.CanvasRenderingContext2D) {
       document.getElementById('app'),
     );
   });
+
+
+
+
 }
 
 window.addEventListener('hashchange', () => {


### PR DESCRIPTION
fix is related to this bug https://trello.com/c/s4b58qPv/550-the-preloadworker-option-and-using-setpdfworkerpath-do-not-work-together-well

The "preloadWorker" option used to load workers beforehand and setPDFWorkerPath, (and other set path functions) is used in config file. WebViewer will try to load workers first and after that process config.js file. And WV loads workers from the wrong location since setPDFWorkerPath is processes later