### PR TITLE
[Bugfix] Fix printing issue on iOS/Android

### DIFF
--- a/src/components/PrintHandler/PrintHandler.scss
+++ b/src/components/PrintHandler/PrintHandler.scss
@@ -23,6 +23,13 @@
     display: block;
     height: 100%;
 
+    // hack for getting safari to print to the whole page
+    top: 0px;
+    bottom: 0px;
+    left: 0px;
+    right: 0px;
+    position: absolute;
+
     img {
       display: block !important;
       max-width: 100%;

--- a/src/components/PrintModal/PrintModal.js
+++ b/src/components/PrintModal/PrintModal.js
@@ -13,6 +13,7 @@ import { getSortStrategies } from 'constants/sortStrategies';
 import actions from 'actions';
 import selectors from 'selectors';
 import LayoutMode from 'constants/layoutMode';
+import { isChromeOniOS } from 'helpers/device';
 
 import './PrintModal.scss';
 import { mapAnnotationToKey, getDataWithKey } from '../../constants/map';
@@ -393,7 +394,7 @@ class PrintModal extends React.PureComponent {
     printHandler.appendChild(fragment);
 
     // Print for Safari browser. Makes Safari 11 consistently work.
-    if (!document.execCommand('print')) {
+    if (!document.execCommand('print') || isChromeOniOS) {
       // fallback for firefox
       window.print();
     }

--- a/src/components/PrintModal/PrintModal.js
+++ b/src/components/PrintModal/PrintModal.js
@@ -13,7 +13,7 @@ import { getSortStrategies } from 'constants/sortStrategies';
 import actions from 'actions';
 import selectors from 'selectors';
 import LayoutMode from 'constants/layoutMode';
-import { isChromeOniOS } from 'helpers/device';
+import { isSafari, isChromeOniOS } from 'helpers/device';
 
 import './PrintModal.scss';
 import { mapAnnotationToKey, getDataWithKey } from '../../constants/map';
@@ -393,9 +393,10 @@ class PrintModal extends React.PureComponent {
 
     printHandler.appendChild(fragment);
 
-    // Print for Safari browser. Makes Safari 11 consistently work.
-    if (!document.execCommand('print') || isChromeOniOS) {
-      // fallback for firefox
+    if (isSafari && !isChromeOniOS) {
+      // Print for Safari browser. Makes Safari 11 consistently work.
+      document.execCommand('print');
+    } else {
       window.print();
     }
     this.closePrintModal();

--- a/src/helpers/device.js
+++ b/src/helpers/device.js
@@ -11,3 +11,5 @@ export const isIOS = window.navigator.userAgent.match(/(iPad|iPhone|iPod)/i) || 
 export const isAndroid = window.navigator.userAgent.match(/Android/i);
 export const isMobileDevice = isIOS || isAndroid || window.navigator.userAgent.match(/webOS|BlackBerry|IEMobile|Opera Mini/i);
 export const isMac = navigator.appVersion.indexOf('Mac') > -1;
+
+export const isChromeOniOS =  window.navigator.userAgent.match(/CriOS\/(.*?) /);

--- a/src/helpers/device.js
+++ b/src/helpers/device.js
@@ -13,8 +13,7 @@ export const isMobileDevice = isIOS || isAndroid || window.navigator.userAgent.m
 export const isMac = navigator.appVersion.indexOf('Mac') > -1;
 
 export const isChrome = (function() {
-  // opera and maxthon have chrome in their useragent string so we need to be careful!
-  // edge does too... stupid sneaky edge
+  // opera, edge, and maxthon have chrome in their useragent string so we need to be careful!
   const opera = window.navigator.userAgent.match(/OPR/);
   const maxthon = window.navigator.userAgent.match(/Maxthon/);
   const edge = window.navigator.userAgent.match(/Edge/);

--- a/src/helpers/device.js
+++ b/src/helpers/device.js
@@ -12,4 +12,17 @@ export const isAndroid = window.navigator.userAgent.match(/Android/i);
 export const isMobileDevice = isIOS || isAndroid || window.navigator.userAgent.match(/webOS|BlackBerry|IEMobile|Opera Mini/i);
 export const isMac = navigator.appVersion.indexOf('Mac') > -1;
 
+export const isChrome = (function() {
+  // opera and maxthon have chrome in their useragent string so we need to be careful!
+  // edge does too... stupid sneaky edge
+  const opera = window.navigator.userAgent.match(/OPR/);
+  const maxthon = window.navigator.userAgent.match(/Maxthon/);
+  const edge = window.navigator.userAgent.match(/Edge/);
+
+  return (window.navigator.userAgent.match(/Chrome\/(.*?) /) && !opera && !maxthon && !edge);
+})();
+
+export const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent) || (/^((?!chrome|android).)*$/.test(navigator.userAgent) && isIOS);
+
+
 export const isChromeOniOS =  window.navigator.userAgent.match(/CriOS\/(.*?) /);

--- a/src/helpers/print.js
+++ b/src/helpers/print.js
@@ -37,7 +37,12 @@ const printPdf = () => {
         printHandler.src = URL.createObjectURL(blob);
 
         var loadListener = function() {
+
+          
           printHandler.contentWindow.print();
+
+
+
           printHandler.removeEventListener('load', loadListener);
           resolve();
         };

--- a/src/redux/selectors/exposedSelectors.js
+++ b/src/redux/selectors/exposedSelectors.js
@@ -1,4 +1,5 @@
 import { workerTypes } from 'constants/types';
+import { isChrome, isAndroid } from 'helpers/device';
 
 // viewer
 export const isElementDisabled = (state, dataElement) =>
@@ -116,11 +117,8 @@ export const getDisabledCustomPanelTabs = state =>
   }, []);
 
 export const isEmbedPrintSupported = state => {
-  const isChrome =
-    window.navigator.userAgent.indexOf('Chrome') > -1 &&
-    window.navigator.userAgent.indexOf('Edge') === -1;
   const isPDF = getDocumentType(state) === workerTypes.PDF;
-  return isPDF && isChrome && state.viewer.useEmbeddedPrint;
+  return isPDF && (isChrome && !isAndroid) && state.viewer.useEmbeddedPrint;
 };
 
 export const getColorMap = state => state.viewer.colorMap;


### PR DESCRIPTION
Safari does weird stuff when printing when printing with a small screen (can either use an iPhone or just resize the window). Trying to set the "width" to something doesn't fix it, but we can use the hack in this fix. Also when using Chrome on iOS, `document.execCommand('print')` return true even when it doesn't do anything ( need to use `window.print()`).