### PR TITLE
[bugfix] Fixed loading encrypted XOD through constructor

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -46,6 +46,9 @@ const App = ({ removeEventHandlers }) => {
   useEffect(() => {
     defineReaderControlAPIs(store);
     window.ControlUtils = {
+      byteRangeCheck: (complete) => {
+        complete(206);
+      },
       // discussed with the team internally, this will be removed in the next major release
       getCustomData: () => {
         console.warn('ControlUtils.getCustomData is deprecated, use instance.getCustomData instead');


### PR DESCRIPTION
`ControlUtils.byteRangeCheck` was missing and thus causing encrypted XODs to fail to load when the encryption object was provided. It was falsified to return 206 since `loadDocument` now does the range check. It should be kept to keep compatibility with the legacy UI for now.