### PR TITLE
[Bugfix] Redraw signature canvas on resize or rotate

### DIFF
--- a/src/components/SignatureModal/SignatureModal.js
+++ b/src/components/SignatureModal/SignatureModal.js
@@ -38,8 +38,8 @@ class SignatureModal extends React.PureComponent {
 
   componentDidMount() {
     this.setUpSignatureCanvas();
-    window.addEventListener('resize', this.setSignatureCanvasSize);
-    window.addEventListener('orientationchange', this.setSignatureCanvasSize);
+    window.addEventListener('resize', this.onResize);
+    window.addEventListener('orientationchange', this.onRotate);
   }
 
   componentDidUpdate(prevProps) {
@@ -62,11 +62,8 @@ class SignatureModal extends React.PureComponent {
   }
 
   componentWillUnmount() {
-    window.removeEventListener('resize', this.setSignatureCanvasSize);
-    window.removeEventListener(
-      'orientationchange',
-      this.setSignatureCanvasSize,
-    );
+    window.removeEventListener('resize', this.onResize);
+    window.removeEventListener('orientationchange', this.onRotate);
   }
 
   setUpSignatureCanvas = () => {
@@ -97,17 +94,34 @@ class SignatureModal extends React.PureComponent {
     }
 
     const canvas = this.canvas.current;
-    const imageData = canvas.toDataURL();
     const { width, height } = canvas.getBoundingClientRect();
     canvas.width = width;
     canvas.height = height;
+  };
+
+  onRotate = () => {
+    const canvas = this.canvas.current;
+    const imageData = canvas.toDataURL();
+    this.setSignatureCanvasSize();
+    this.redrawSignatureCanvas(imageData);
+  };
+
+  onResize = () => {
+    const canvas = this.canvas.current;
+    const imageData = canvas.toDataURL();
+    this.setSignatureCanvasSize();
+    this.redrawSignatureCanvas(imageData);
+  };
+
+  redrawSignatureCanvas = signatureData => {
+    const canvas = this.canvas.current;
 
     const image = new Image();
     const ctx = canvas.getContext('2d');
     image.onload = function() {
       ctx.drawImage(image, 0, 0, ctx.canvas.width, ctx.canvas.height);
     };
-    image.src = imageData;
+    image.src = signatureData;
   };
 
   handleFinishDrawing = e => {

--- a/src/components/SignatureModal/SignatureModal.js
+++ b/src/components/SignatureModal/SignatureModal.js
@@ -100,6 +100,11 @@ class SignatureModal extends React.PureComponent {
     const { width, height } = canvas.getBoundingClientRect();
     canvas.width = width;
     canvas.height = height;
+
+    if (!this.signatureTool.isEmptySignature()) {
+      // if the canvas is resized the content get cleared. So redraw it
+      this.signatureTool.drawAnnot();
+    }
   };
 
   handleFinishDrawing = e => {

--- a/src/components/SignatureModal/SignatureModal.js
+++ b/src/components/SignatureModal/SignatureModal.js
@@ -100,26 +100,24 @@ class SignatureModal extends React.PureComponent {
   };
 
   onRotate = () => {
-    const canvas = this.canvas.current;
-    const imageData = canvas.toDataURL();
+    const imageData = this.canvas.current.toDataURL();
     this.setSignatureCanvasSize();
     this.redrawSignatureCanvas(imageData);
   };
 
   onResize = () => {
-    const canvas = this.canvas.current;
-    const imageData = canvas.toDataURL();
+    const imageData = this.canvas.current.toDataURL();
     this.setSignatureCanvasSize();
     this.redrawSignatureCanvas(imageData);
   };
 
   redrawSignatureCanvas = signatureData => {
     const canvas = this.canvas.current;
+    const ctx = canvas.getContext('2d');
 
     const image = new Image();
-    const ctx = canvas.getContext('2d');
     image.onload = function() {
-      ctx.drawImage(image, 0, 0, ctx.canvas.width, ctx.canvas.height);
+      ctx.drawImage(image, 0, 0, canvas.width, canvas.height);
     };
     image.src = signatureData;
   };

--- a/src/components/SignatureModal/SignatureModal.js
+++ b/src/components/SignatureModal/SignatureModal.js
@@ -97,14 +97,17 @@ class SignatureModal extends React.PureComponent {
     }
 
     const canvas = this.canvas.current;
+    const imageData = canvas.toDataURL();
     const { width, height } = canvas.getBoundingClientRect();
     canvas.width = width;
     canvas.height = height;
 
-    if (!this.signatureTool.isEmptySignature()) {
-      // if the canvas is resized the content get cleared. So redraw it
-      this.signatureTool.drawAnnot();
-    }
+    const image = new Image();
+    const ctx = canvas.getContext('2d');
+    image.onload = function() {
+      ctx.drawImage(image, 0, 0, ctx.canvas.width, ctx.canvas.height);
+    };
+    image.src = imageData;
   };
 
   handleFinishDrawing = e => {


### PR DESCRIPTION
For a ticket a  customer was saying the signature canvas clear when the screen rotate (I'm guessing they are on a mobile device), so I made it redraw after it get clear.  

![signatureResize](https://user-images.githubusercontent.com/45575633/69188949-5c874400-0ad2-11ea-8321-227c8aa64bf1.gif)

Another solution would be do something like
```
        const image = new Image();
        const ctx = canvas.getContext('2d');
        image.onload = function() {
          ctx.drawImage(image, 0, 0);
        };
        image.src = canvas.toDataURL();
```

This might be good if we don't want to use "signatureTool.drawAnnot"