### PR TITLE
[Feature] Delays progress modal for 1 second

### DIFF
--- a/src/helpers/loadDocument.js
+++ b/src/helpers/loadDocument.js
@@ -29,7 +29,11 @@ export default (state, dispatch, extraOptions) => {
             partRetriever.setErrorCallback(fireError);
           }
 
-          dispatch(actions.openElement('progressModal'));
+          // Delay opening of progress for 1 sec
+          setTimeout(() => {
+            dispatch(actions.openElement('progressModal'));
+          }, 1000);
+
           core.loadAsync(partRetriever, { ...extraOptions, ...docOptions });
         })
         .catch(error => {

--- a/src/redux/actions/exposedActions.js
+++ b/src/redux/actions/exposedActions.js
@@ -30,8 +30,9 @@ export const openElement = dataElement => (dispatch, getState) => {
     dispatch(setActiveLeftPanel(dataElement));
   } else {
     if (dataElement === 'progressModal') {
-      // if document already loaded no need to open progressModal
-      if (!getState().viewer.isDocumentLoaded) {
+      // if document already loaded and there is no error message
+      // no need to open progressModal
+      if (!getState().viewer.isDocumentLoaded && !getState().viewer.errorMessage) {
         dispatch({ type: 'OPEN_ELEMENT', payload: { dataElement } });
       } 
     } else {

--- a/src/redux/actions/exposedActions.js
+++ b/src/redux/actions/exposedActions.js
@@ -29,7 +29,15 @@ export const openElement = dataElement => (dispatch, getState) => {
     }
     dispatch(setActiveLeftPanel(dataElement));
   } else {
-    dispatch({ type: 'OPEN_ELEMENT', payload: { dataElement } });
+    if (dataElement === 'progressModal') {
+      // if document already loaded no need to open progressModal
+      if (!getState().viewer.isDocumentLoaded) {
+        dispatch({ type: 'OPEN_ELEMENT', payload: { dataElement } });
+      } 
+    } else {
+      dispatch({ type: 'OPEN_ELEMENT', payload: { dataElement } });
+    }
+    
     fireEvent('visibilityChanged', { element: dataElement, isVisible: true });
 
     if (dataElement === 'leftPanel' && !isLeftPanelOpen) {


### PR DESCRIPTION
This delays opening progress modal for 1 sec, and in openElement action, it checks whether the document is actually loaded or not. Since it is delayed for 1 sec, doc is already loaded.

https://trello.com/c/UowfeUXo/561-hide-the-loading-bar-for-half-a-second-and-fade-it-in-if-loading-still-isnt-finished