### PR TITLE
Bug fix/show correct annotation author on print

### DIFF
--- a/src/components/PrintModal/PrintModal.js
+++ b/src/components/PrintModal/PrintModal.js
@@ -392,7 +392,7 @@ class PrintModal extends React.PureComponent {
 
     info.className = 'note__info';
     info.innerHTML = `
-      Author: ${annotation.Author || ''} &nbsp;&nbsp;
+      Author: ${core.getDisplayAuthor(annotation) || ''} &nbsp;&nbsp;
       Subject: ${annotation.Subject} &nbsp;&nbsp;
       Date: ${dayjs(annotation.DateCreated).format('D/MM/YYYY h:mm:ss A')}
     `;


### PR DESCRIPTION
Fix for ticket: https://pdftron.freshdesk.com/a/tickets/9342
It seems when the  "get annotation display author name" function is overrided, it's not shown correctly in the print modal.