### PR TITLE
Ensured that row count is always an integer

### DIFF
--- a/src/components/ThumbnailsPanel/ThumbnailsPanel.js
+++ b/src/components/ThumbnailsPanel/ThumbnailsPanel.js
@@ -288,7 +288,9 @@ class ThumbnailsPanel extends React.PureComponent {
                 height={height}
                 width={width}
                 rowHeight={this.thumbnailHeight}
-                rowCount={totalPages / numberOfColumns}
+                // Round it to a whole number because React-Virtualized list library doesn't round it for us and throws errors when rendering non whole number rows
+                // use ceiling rather than floor so that an extra row can be created in case the items can't be evenly distributed between rows
+                rowCount={Math.ceil(totalPages / numberOfColumns)}
                 rowRenderer={this.renderThumbnails}
                 overscanRowCount={10}
                 style={{ outline: 'none' }}


### PR DESCRIPTION
Fix for ticket: https://pdftron.freshdesk.com/a/tickets/9383
Error was something along the lines of:
CellSizeAndPositionManager.js:66 Uncaught (in promise) Error: Requested index -1 is outside of range 0..0

It came from thumbnail panel which used the react virtualized list.

For reference, it looks like a known opened issue:
https://github.com/bvaughn/react-virtualized/issues/1016