### PR TITLE
[CHANGE] Allow instance.updateElement to change the colors in the color palette

### DIFF
--- a/src/apis/updateElement.js
+++ b/src/apis/updateElement.js
@@ -1,10 +1,10 @@
 import actions from 'actions';
 
 /**
- * Update an element in the viewer. Currently this API can only update elements that have a Button class name.
+ * Update an element in the viewer.
  * @method WebViewerInstance#updateElement
- * @param {string} dataElement the data element of the element that will be updated.
- * @param {object} props An object that is used to override an existing item's properties.
+ * @param {string} dataElement the data element of the element that will be updated. Valid values are 'colorPalette', and HTML elements that have 'Button' in the class name.
+ * @param {*} props An object or an array that is used to override an existing item's properties.
  * @example
 WebViewer(...)
   .then(function(instance) {
@@ -12,6 +12,8 @@ WebViewer(...)
       img: 'path/to/image',
       title: 'new_tooltip',
     })
+
+    instance.updateElement('colorPalette', ['#FFFFFF', 'transparency', '#000000'])
   });
  */
 export default store => (dataElement, overrides) => {

--- a/src/apis/updateElement.js
+++ b/src/apis/updateElement.js
@@ -15,5 +15,44 @@ WebViewer(...)
   });
  */
 export default store => (dataElement, overrides) => {
-  store.dispatch(actions.setCustomElementOverrides(dataElement, overrides));
+  switch (dataElement) {
+    case 'colorPalette':
+      overrides = validateColorPaletteOverrides(overrides);
+      break;
+    default:
+      overrides = validateButtonOverrides(overrides);
+  }
+
+  if (overrides) {
+    store.dispatch(actions.setCustomElementOverrides(dataElement, overrides));
+  }
+};
+
+const validateColorPaletteOverrides = overrides => {
+  if (!Array.isArray(overrides)) {
+    return console.warn(
+      'The second argument needs to be an array of strings to update the color palette',
+    );
+  }
+
+  // examples of valid colors are: '#f0f0f0', '#FFFFFF'
+  const isValidColor = color =>
+    color === 'transparency' ||
+    (color.startsWith('#') && color.split('#')[1].length === 6);
+
+  if (!overrides.every(isValidColor)) {
+    return console.warn('The color must be \'transparency\' or a hex color string. For example #F0F0F0');
+  }
+
+  return overrides;
+};
+
+const validateButtonOverrides = overrides => {
+  if (overrides !== null && typeof overrides !== 'object') {
+    return console.warn(
+      'The second argument needs to be an object to update a button',
+    );
+  }
+
+  return overrides;
 };

--- a/src/apis/updateElement.js
+++ b/src/apis/updateElement.js
@@ -15,9 +15,5 @@ WebViewer(...)
   });
  */
 export default store => (dataElement, overrides) => {
-  if (overrides !== null && typeof overrides !== 'object') {
-    return console.warn('The second argument to instance.updateElement needs to be an object.');
-  }
-
   store.dispatch(actions.setCustomElementOverrides(dataElement, overrides));
 };

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector, shallowEqual } from 'react-redux';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
@@ -11,7 +11,6 @@ import selectors from 'selectors';
 import './Button.scss';
 
 const propTypes = {
-  disable: PropTypes.bool,
   isActive: PropTypes.bool,
   mediaQueryClassName: PropTypes.string,
   img: PropTypes.string,
@@ -24,10 +23,10 @@ const propTypes = {
 };
 
 const Button = props => {
-  const [isElementDisabled, customOverrides] = useSelector(state => [
+  const [isElementDisabled, customOverrides = {}] = useSelector(state => [
     selectors.isElementDisabled(state, props.dataElement),
     selectors.getCustomElementOverrides(state, props.dataElement),
-  ]);
+  ], shallowEqual);
 
   props = { ...props, ...customOverrides };
   const {

--- a/src/components/ColorPalette/ColorPalette.js
+++ b/src/components/ColorPalette/ColorPalette.js
@@ -1,92 +1,181 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
 import Icon from 'components/Icon';
 
 import getBrightness from 'helpers/getBrightness';
+import selectors from 'selectors';
 
 import './ColorPalette.scss';
+
+const dataElement = 'colorPalette';
 
 class ColorPalette extends React.PureComponent {
   static propTypes = {
     property: PropTypes.string.isRequired,
     color: PropTypes.object.isRequired,
     onStyleChange: PropTypes.func.isRequired,
-  }
+    overridePalette: PropTypes.oneOfType(PropTypes.object, PropTypes.array),
+  };
 
   constructor(props) {
     super(props);
-    this.palette = [
-      ['#F1A099', '#FFC67B', '#FFE6A2', '#80E5B1', '#92E8E8', '#A6A1E6', '#E2A1E6'],
-      ['#E44234', '#FF8D00', '#FFCD45', '#00CC63', '#25D2D1', '#4E7DE9', '#C544CE'],
-      ['#88271F', '#B54800', '#F69A00', '#007A3B', '#167E7D', '#2E4B8B', '#76287B'],
-      [null, '#FFFFFF', '#CDCDCD', '#9C9C9C', '#696969', '#373737', '#000000'],
+    this.defaultPalette = [
+      '#F1A099',
+      '#FFC67B',
+      '#FFE6A2',
+      '#80E5B1',
+      '#92E8E8',
+      '#A6A1E6',
+      '#E2A1E6',
+      '#E44234',
+      '#FF8D00',
+      '#FFCD45',
+      '#00CC63',
+      '#25D2D1',
+      '#4E7DE9',
+      '#C544CE',
+      '#88271F',
+      '#B54800',
+      '#F69A00',
+      '#007A3B',
+      '#167E7D',
+      '#2E4B8B',
+      '#76287B',
+      'transparency',
+      '#FFFFFF',
+      '#CDCDCD',
+      '#9C9C9C',
+      '#696969',
+      '#373737',
+      '#000000',
     ];
   }
 
   setColor = e => {
     const { property, onStyleChange } = this.props;
     const bg = e.target.style.backgroundColor; // rgb(r, g, b);
-    const rgba = bg ? bg.slice(bg.indexOf('(') + 1, -1).split(',') : [0, 0, 0, 0];
-    const color = new window.Annotations.Color(rgba[0], rgba[1], rgba[2], rgba[3]);
+    const rgba = bg
+      ? bg.slice(bg.indexOf('(') + 1, -1).split(',')
+      : [0, 0, 0, 0];
+    const color = new window.Annotations.Color(
+      rgba[0],
+      rgba[1],
+      rgba[2],
+      rgba[3],
+    );
     onStyleChange(property, color);
-  }
+  };
 
   renderTransparencyCell = (bg, key) => {
     const { property } = this.props;
-    const shouldRenderDummyCell = property === 'TextColor' || property === 'StrokeColor';
+    const shouldRenderDummyCell =
+      property === 'TextColor' || property === 'StrokeColor';
 
     if (shouldRenderDummyCell) {
       return <div className="dummy-cell" key={key}></div>;
     }
 
     const diagonalLine = (
-      <svg width="100%" height="100%" style={{ position: 'absolute', top: '0px', left: '0px' }}>
-        <line x1="0%" y1="100%" x2="100%" y2="0%" strokeWidth="1" stroke="#e44234" strokeLinecap="square" />
+      <svg
+        width="100%"
+        height="100%"
+        style={{ position: 'absolute', top: '0px', left: '0px' }}
+      >
+        <line
+          x1="0%"
+          y1="100%"
+          x2="100%"
+          y2="0%"
+          strokeWidth="1"
+          stroke="#e44234"
+          strokeLinecap="square"
+        />
       </svg>
     );
 
     return (
-      <div className="cell" key={key} onClick={this.setColor}>
+      <div
+        className="cell"
+        key={key}
+        onClick={this.setColor}
+        style={{ backgroundColor: '#FFFFFF', border: '1px solid #e0e0e0' }}
+      >
         {this.renderCheckMark(bg)}
         {diagonalLine}
       </div>
     );
-  }
+  };
 
-  renderColorCell = (bg, key) => (
-    <div className="cell" key={key} style={{ backgroundColor: bg }} onClick={this.setColor}>
-      {this.renderCheckMark(bg)}
-    </div>
-  )
+  renderColorCell = (bg, key) => {
+    let style = { backgroundColor: bg };
+
+    if (bg === '#FFFFFF') {
+      style = Object.assign(style, {
+        border: '1px solid #e0e0e0',
+      });
+    }
+
+    return (
+      <div className="cell" key={key} style={style} onClick={this.setColor}>
+        {this.renderCheckMark(bg)}
+      </div>
+    );
+  };
 
   renderCheckMark = bg => {
     const { color } = this.props;
-    const isColorPicked = color.toHexString() === bg;
+    const hexColor = color.toHexString();
 
-    if (!isColorPicked) {
-      return null;
+    let isColorPicked;
+    if (bg === 'transparency') {
+      isColorPicked = hexColor === null;
+    } else {
+      isColorPicked = hexColor === bg;
     }
 
-    return <Icon className={`check-mark ${getBrightness(color)}`} glyph="ic_check_black_24px" />;
-  }
+    return isColorPicked ? (
+      <Icon
+        className={`check-mark ${getBrightness(color)}`}
+        glyph="ic_check_black_24px"
+      />
+    ) : null;
+  };
 
   render() {
+    const { overridePalette } = this.props;
+
+    let palette = this.defaultPalette;
+    if (Array.isArray(overridePalette) && overridePalette.length) {
+      palette = overridePalette;
+    }
+
+    const MAX = 7;
+    const twoDPalette = [];
+    for (let i = 0; i < palette.length; i += 7) {
+      twoDPalette.push(palette.slice(i, i + 7));
+    }
+
     return (
-      <div className="ColorPalette" data-element="colorPalette">
-        {this.palette.map((row, i) =>
+      <div className="ColorPalette" data-element={dataElement}>
+        {twoDPalette.map((row, i) => (
           <div className="row" key={i}>
             {row.map((bg, j) => {
-              if (i === 3 && j === 0) {
+              if (bg === 'transparency') {
                 return this.renderTransparencyCell(bg, j);
               }
               return this.renderColorCell(bg, j);
             })}
-          </div>,
-        )}
+          </div>
+        ))}
       </div>
     );
   }
 }
 
-export default ColorPalette;
+const mapStateToProps = state => ({
+  overridePalette: selectors.getCustomElementOverrides(state, dataElement),
+});
+
+export default connect(mapStateToProps)(ColorPalette);

--- a/src/components/ColorPalette/ColorPalette.js
+++ b/src/components/ColorPalette/ColorPalette.js
@@ -125,8 +125,8 @@ class ColorPalette extends React.PureComponent {
     const hexColor = color.toHexString();
 
     let isColorPicked;
-    if (bg === 'transparency') {
-      isColorPicked = hexColor === null;
+    if (hexColor === null) {
+      isColorPicked = bg === 'transparency';
     } else {
       isColorPicked = hexColor.toLowerCase() === bg.toLowerCase();
     }

--- a/src/components/ColorPalette/ColorPalette.js
+++ b/src/components/ColorPalette/ColorPalette.js
@@ -19,39 +19,36 @@ class ColorPalette extends React.PureComponent {
     overridePalette: PropTypes.oneOfType(PropTypes.object, PropTypes.array),
   };
 
-  constructor(props) {
-    super(props);
-    this.defaultPalette = [
-      '#F1A099',
-      '#FFC67B',
-      '#FFE6A2',
-      '#80E5B1',
-      '#92E8E8',
-      '#A6A1E6',
-      '#E2A1E6',
-      '#E44234',
-      '#FF8D00',
-      '#FFCD45',
-      '#00CC63',
-      '#25D2D1',
-      '#4E7DE9',
-      '#C544CE',
-      '#88271F',
-      '#B54800',
-      '#F69A00',
-      '#007A3B',
-      '#167E7D',
-      '#2E4B8B',
-      '#76287B',
-      'transparency',
-      '#FFFFFF',
-      '#CDCDCD',
-      '#9C9C9C',
-      '#696969',
-      '#373737',
-      '#000000',
-    ];
-  }
+  defaultPalette = [
+    '#F1A099',
+    '#FFC67B',
+    '#FFE6A2',
+    '#80E5B1',
+    '#92E8E8',
+    '#A6A1E6',
+    '#E2A1E6',
+    '#E44234',
+    '#FF8D00',
+    '#FFCD45',
+    '#00CC63',
+    '#25D2D1',
+    '#4E7DE9',
+    '#C544CE',
+    '#88271F',
+    '#B54800',
+    '#F69A00',
+    '#007A3B',
+    '#167E7D',
+    '#2E4B8B',
+    '#76287B',
+    'transparency',
+    '#FFFFFF',
+    '#CDCDCD',
+    '#9C9C9C',
+    '#696969',
+    '#373737',
+    '#000000',
+  ];
 
   setColor = e => {
     const { property, onStyleChange } = this.props;
@@ -68,13 +65,13 @@ class ColorPalette extends React.PureComponent {
     onStyleChange(property, color);
   };
 
-  renderTransparencyCell = (bg, key) => {
+  renderTransparencyCell = bg => {
     const { property } = this.props;
     const shouldRenderDummyCell =
       property === 'TextColor' || property === 'StrokeColor';
 
     if (shouldRenderDummyCell) {
-      return <div className="dummy-cell" key={key}></div>;
+      return <div className="dummy-cell" />;
     }
 
     const diagonalLine = (
@@ -98,7 +95,6 @@ class ColorPalette extends React.PureComponent {
     return (
       <div
         className="cell"
-        key={key}
         onClick={this.setColor}
         style={{ backgroundColor: '#FFFFFF', border: '1px solid #e0e0e0' }}
       >
@@ -108,7 +104,7 @@ class ColorPalette extends React.PureComponent {
     );
   };
 
-  renderColorCell = (bg, key) => {
+  renderColorCell = bg => {
     let style = { backgroundColor: bg };
 
     if (bg === '#FFFFFF') {
@@ -118,7 +114,7 @@ class ColorPalette extends React.PureComponent {
     }
 
     return (
-      <div className="cell" key={key} style={style} onClick={this.setColor}>
+      <div className="cell" style={style} onClick={this.setColor}>
         {this.renderCheckMark(bg)}
       </div>
     );
@@ -145,29 +141,16 @@ class ColorPalette extends React.PureComponent {
 
   render() {
     const { overridePalette } = this.props;
-
-    let palette = this.defaultPalette;
-    if (Array.isArray(overridePalette) && overridePalette.length) {
-      palette = overridePalette;
-    }
-
-    const MAX = 7;
-    const twoDPalette = [];
-    for (let i = 0; i < palette.length; i += 7) {
-      twoDPalette.push(palette.slice(i, i + 7));
-    }
+    const palette = overridePalette || this.defaultPalette;
 
     return (
       <div className="ColorPalette" data-element={dataElement}>
-        {twoDPalette.map((row, i) => (
-          <div className="row" key={i}>
-            {row.map((bg, j) => {
-              if (bg === 'transparency') {
-                return this.renderTransparencyCell(bg, j);
-              }
-              return this.renderColorCell(bg, j);
-            })}
-          </div>
+        {palette.map((bg, i) => (
+          <React.Fragment key={i}>
+            {bg === 'transparency'
+              ? this.renderTransparencyCell(bg)
+              : this.renderColorCell(bg)}
+          </React.Fragment>
         ))}
       </div>
     );

--- a/src/components/ColorPalette/ColorPalette.js
+++ b/src/components/ColorPalette/ColorPalette.js
@@ -128,7 +128,7 @@ class ColorPalette extends React.PureComponent {
     if (bg === 'transparency') {
       isColorPicked = hexColor === null;
     } else {
-      isColorPicked = hexColor === bg;
+      isColorPicked = hexColor.toLowerCase() === bg.toLowerCase();
     }
 
     return isColorPicked ? (

--- a/src/components/ColorPalette/ColorPalette.js
+++ b/src/components/ColorPalette/ColorPalette.js
@@ -16,7 +16,7 @@ class ColorPalette extends React.PureComponent {
     property: PropTypes.string.isRequired,
     color: PropTypes.object.isRequired,
     onStyleChange: PropTypes.func.isRequired,
-    overridePalette: PropTypes.oneOfType(PropTypes.object, PropTypes.array),
+    overridePalette: PropTypes.array,
   };
 
   defaultPalette = [

--- a/src/components/ColorPalette/ColorPalette.scss
+++ b/src/components/ColorPalette/ColorPalette.scss
@@ -10,14 +10,6 @@
     flex-direction: row;
     margin: 1px 0;
 
-    &:nth-child(4) {
-      .cell:nth-child(1), .cell:nth-child(2) {
-        border: 1px solid #e0e0e0;
-        overflow: hidden;
-        background-color: $white;
-      }
-    }
-
     .cell {
       @extend %cell;
       position: relative;

--- a/src/components/ColorPalette/ColorPalette.scss
+++ b/src/components/ColorPalette/ColorPalette.scss
@@ -4,6 +4,7 @@
   margin-top: 6px;
   display: flex;
   flex-wrap: wrap;
+  justify-content: center;
 
   .cell {
     @extend %cell;
@@ -13,11 +14,6 @@
     border-radius: 1px;
     border: 1px solid transparent;
     cursor: pointer;
-
-    @include mobile {
-      height: 30px;
-      margin: 0 1.2px;
-    }
   
     .check-mark {
       width: 20px;

--- a/src/components/ColorPalette/ColorPalette.scss
+++ b/src/components/ColorPalette/ColorPalette.scss
@@ -3,45 +3,36 @@
 .ColorPalette {
   margin-top: 6px;
   display: flex;
-  flex-direction: column;
+  flex-wrap: wrap;
 
-  .row {
-    display: flex;
-    flex-direction: row;
-    margin: 1px 0;
+  .cell {
+    @extend %cell;
+    position: relative;
+    justify-content: center;
+    align-items: center;
+    border-radius: 1px;
+    border: 1px solid transparent;
+    cursor: pointer;
 
-    .cell {
-      @extend %cell;
-      position: relative;
-      justify-content: center;
-      align-items: center;
-      border-radius: 1px;
-      border: 1px solid transparent;
+    @include mobile {
+      height: 30px;
+      margin: 0 1.2px;
+    }
+  
+    .check-mark {
+      width: 20px;
+      height: 20px;
 
-      @include mobile {
-        height: 30px;
-        margin: 0 1.2px;
+      &.dark {
+        color: rgba(0, 0, 0, 0.54);
       }
 
-      &:hover {
-        cursor: pointer;
-      }
-    
-      .check-mark {
-        width: 20px;
-        height: 20px;
-
-        &.dark {
-          color: rgba(0, 0, 0, 0.54);
-        }
-
-        &.bright {
-          color: rgba(255, 255, 255, 0.70);
-        }
+      &.bright {
+        color: rgba(255, 255, 255, 0.70);
       }
     }
   }
-
+  
   .dummy-cell {
     @extend %cell;
   }

--- a/src/constants/styles.scss
+++ b/src/constants/styles.scss
@@ -115,7 +115,7 @@ $signature-modal-shared-color: #E1E1E3;
 }
 
 %cell {
-  flex: 1 0 28px;
+  width: 30px;
   height: 26px;
   display: flex;
   margin: 0 1px;

--- a/src/constants/styles.scss
+++ b/src/constants/styles.scss
@@ -115,7 +115,6 @@ $signature-modal-shared-color: #E1E1E3;
 }
 
 %cell {
-  flex: 1, 0;
   width: 30px;
   height: 26px;
   display: flex;
@@ -123,9 +122,10 @@ $signature-modal-shared-color: #E1E1E3;
 
   @include mobile {
     height: 30px;
-    margin: 0 1.2px;
+    width: 13.5%;
   }
 }
+
 // https://css-tricks.com/snippets/css/prevent-long-urls-from-breaking-out-of-container/
 %word-wrap {
   overflow-wrap: break-word;

--- a/src/constants/styles.scss
+++ b/src/constants/styles.scss
@@ -115,10 +115,11 @@ $signature-modal-shared-color: #E1E1E3;
 }
 
 %cell {
+  flex: 1, 0;
   width: 30px;
   height: 26px;
   display: flex;
-  margin: 0 1px;
+  margin: 1px;
 
   @include mobile {
     height: 30px;

--- a/src/redux/initialState.js
+++ b/src/redux/initialState.js
@@ -159,7 +159,9 @@ export default {
     tab: {
       signatureModal: 'inkSignaturePanelButton',
     },
-    customElementOverrides: {},
+    customElementOverrides: {
+      colorPalette: ['#000000', '#F1A099', '#FFC67B', 'transparency', '#FFE6A2', '#80E5B1', '#92E8E8', '#A6A1E6', '#E2A1E6', '#FFCD45'],
+    },
     activeHeaderGroup: 'default',
     activeToolName: 'AnnotationEdit',
     activeToolStyles: {},

--- a/src/redux/initialState.js
+++ b/src/redux/initialState.js
@@ -159,9 +159,7 @@ export default {
     tab: {
       signatureModal: 'inkSignaturePanelButton',
     },
-    customElementOverrides: {
-      colorPalette: ['#000000', '#F1A099', '#FFC67B', 'transparency', '#FFE6A2', '#80E5B1', '#92E8E8', '#A6A1E6', '#E2A1E6', '#FFCD45'],
-    },
+    customElementOverrides: {},
     activeHeaderGroup: 'default',
     activeToolName: 'AnnotationEdit',
     activeToolStyles: {},

--- a/src/redux/selectors/exposedSelectors.js
+++ b/src/redux/selectors/exposedSelectors.js
@@ -128,8 +128,7 @@ export const getSignatureFonts = state => state.viewer.signatureFonts;
 
 export const getSelectedTab = (state, id) => state.viewer.tab[id];
 
-// TODO: check if we have to default to an object here
-export const getCustomElementOverrides = (state, dataElement) => state.viewer.customElementOverrides[dataElement] || {};
+export const getCustomElementOverrides = (state, dataElement) => state.viewer.customElementOverrides[dataElement];
 
 export const getPopupItems = (state, popupDataElement) =>
   state.viewer[popupDataElement] || [];

--- a/src/redux/selectors/exposedSelectors.js
+++ b/src/redux/selectors/exposedSelectors.js
@@ -128,6 +128,7 @@ export const getSignatureFonts = state => state.viewer.signatureFonts;
 
 export const getSelectedTab = (state, id) => state.viewer.tab[id];
 
+// TODO: check if we have to default to an object here
 export const getCustomElementOverrides = (state, dataElement) => state.viewer.customElementOverrides[dataElement] || {};
 
 export const getPopupItems = (state, popupDataElement) =>


### PR DESCRIPTION
QA:
- In the console, do `readerControl.updateElement('colorPalette', ['#FFFFFF'])`
- Now the palette should only contain the white color

This is a request from a customer who wishes to customize the colors that are available in the color palette.  There're some noises in this PR since I formatted the component using Prettier, and there're some refactoring as well. I have to do some refactoring because the previous implementation has some hardcoded values that don't work well anymore when users are able to customize the colors.