### PR TITLE
[Bugfix] Fixed incorrect class name in Edge/IE

### DIFF
--- a/src/helpers/documentContainerHelper.js
+++ b/src/helpers/documentContainerHelper.js
@@ -77,7 +77,7 @@ const shrinkContainerWidthBy = (panelWidth, container) => {
 
 export const getClassNameInIE = ({ isHeaderOpen, isSearchOverlayOpen }) => [
   'DocumentContainer',
-  isHeaderOpen ? 'full-height' : '',
+  isHeaderOpen ? '' : 'no-header',
   isSearchOverlayOpen ? 'search-overlay' : '',
 ].join(' ').trim();
 


### PR DESCRIPTION
If you hide the header (`readerControl.closeElement('header')`), there is a small gap at the bottom when using Edge or IE

![image](https://user-images.githubusercontent.com/45575633/72110786-ec38ba00-32ed-11ea-92fa-9ad8cc9d7eda.png)

The issue is `documentContainer` should have a 'no-header' class (like what Chrome and other browsers are getting) instead of a 'full-height' class. I'm not sure if 'full-height' is a class we removed because it currently doesn't do anything. 