### PR TITLE
Bugfix/display line breaks for comments

### DIFF
--- a/src/components/AnnotationContentOverlay/AnnotationContentOverlay.scss
+++ b/src/components/AnnotationContentOverlay/AnnotationContentOverlay.scss
@@ -17,5 +17,6 @@
 
   .contents, .replies {
     margin-top: 5px;
+    white-space: pre-wrap;
   }
 }

--- a/src/components/PrintModal/PrintModal.js
+++ b/src/components/PrintModal/PrintModal.js
@@ -406,6 +406,7 @@ class PrintModal extends React.PureComponent {
 
     contentElement.className = 'note__content';
     if (contentText) {
+      contentElement.style.whiteSpace = 'pre-wrap';
       contentElement.innerHTML = `${contentText}`;
     }
     return contentElement;

--- a/src/components/PrintModal/PrintModal.js
+++ b/src/components/PrintModal/PrintModal.js
@@ -406,6 +406,7 @@ class PrintModal extends React.PureComponent {
 
     contentElement.className = 'note__content';
     if (contentText) {
+      // ensure that new lines are preserved and rendered properly
       contentElement.style.whiteSpace = 'pre-wrap';
       contentElement.innerHTML = `${contentText}`;
     }


### PR DESCRIPTION
https://trello.com/c/8bu0WqS8/685-printing-with-comments-does-not-show-correct-line-breaks

1. Create a comment / reply with line breaks.

On print with comments or hover over the annotation with the comment, it should be able to display the comment correctly.