### PR TITLE
[FIX]Add option to disable wild-card-search in search panel and applyWatermark in print panel

### DIFF
--- a/src/components/PrintModal/PrintModal.js
+++ b/src/components/PrintModal/PrintModal.js
@@ -35,6 +35,7 @@ class PrintModal extends React.PureComponent {
     sortStrategy: PropTypes.string.isRequired,
     colorMap: PropTypes.object.isRequired,
     layoutMode: PropTypes.string.isRequired,
+    isApplyWatermarkDisabled: PropTypes.bool,
   };
 
   constructor() {
@@ -461,7 +462,7 @@ class PrintModal extends React.PureComponent {
   };
 
   render() {
-    const { isDisabled, t } = this.props;
+    const { isDisabled, t, isApplyWatermarkDisabled } = this.props;
 
     if (isDisabled) {
       return null;
@@ -552,9 +553,9 @@ class PrintModal extends React.PureComponent {
                 />
               </form>
             </div>
-            {this.state.allowWatermarkModal && (
+            {!isApplyWatermarkDisabled && (
               <button
-                id="applyWatermark"
+                data-element="applyWatermark"
                 className="apply-watermark"
                 disabled={isPrinting}
                 onClick={() => {
@@ -598,6 +599,7 @@ class PrintModal extends React.PureComponent {
 const mapStateToProps = state => ({
   isEmbedPrintSupported: selectors.isEmbedPrintSupported(state),
   isDisabled: selectors.isElementDisabled(state, 'printModal'),
+  isApplyWatermarkDisabled: selectors.isElementDisabled(state, 'applyWatermark'),
   isOpen: selectors.isElementOpen(state, 'printModal'),
   currentPage: selectors.getCurrentPage(state),
   printQuality: selectors.getPrintQuality(state),

--- a/src/components/SearchOverlay/SearchOverlay.js
+++ b/src/components/SearchOverlay/SearchOverlay.js
@@ -23,6 +23,7 @@ class SearchOverlay extends React.PureComponent {
     isDisabled: PropTypes.bool,
     isSearchPanelOpen: PropTypes.bool,
     isSearchPanelDisabled: PropTypes.bool,
+    isWildCardSearchDisabled: PropTypes.bool,
     searchValue: PropTypes.string,
     isCaseSensitive: PropTypes.bool,
     isWholeWord: PropTypes.bool,
@@ -340,7 +341,16 @@ class SearchOverlay extends React.PureComponent {
   }
 
   render() {
-    const { isDisabled, t, isSearchPanelOpen, isSearchPanelDisabled, results, searchValue, activeResultIndex } = this.props;
+    const {
+      isDisabled,
+      t,
+      isSearchPanelOpen,
+      isSearchPanelDisabled,
+      results,
+      searchValue,
+      activeResultIndex,
+      isWildCardSearchDisabled,
+    } = this.props;
 
     if (isDisabled) {
       return null;
@@ -379,9 +389,10 @@ class SearchOverlay extends React.PureComponent {
             <div className="search-option">
               <Input id="whole-word-option" type="checkbox" ref={this.wholeWordInput} onChange={this.onChangeWholeWord} label={t('option.searchPanel.wholeWordOnly')} />
             </div>
-            <div className="search-option">
+            { !isWildCardSearchDisabled &&
+            <div className="search-option" data-element="wildCardSearchOption">
               <Input id="wild-card-option" type="checkbox" ref={this.wildcardInput} onChange={this.onChangeWildcard} label={t('option.searchPanel.wildcard')} />
-            </div>
+            </div>}
           </div>
           {!isSearchPanelOpen &&
             this.state.noResultSingleSearch &&
@@ -397,6 +408,7 @@ class SearchOverlay extends React.PureComponent {
 const mapStateToProps = state => ({
   isSearchPanelOpen: selectors.isElementOpen(state, 'searchPanel'),
   isSearchPanelDisabled: selectors.isElementDisabled(state, 'searchPanel'),
+  isWildCardSearchDisabled: selectors.isElementDisabled(state, 'wildCardSearchOption'),
   searchValue: selectors.getSearchValue(state),
   isCaseSensitive: selectors.isCaseSensitive(state),
   isWholeWord: selectors.isWholeWord(state),

--- a/src/components/SearchPanel/SearchPanel.js
+++ b/src/components/SearchPanel/SearchPanel.js
@@ -18,6 +18,7 @@ import './SearchPanel.scss';
 class SearchPanel extends React.PureComponent {
   static propTypes = {
     isDisabled: PropTypes.bool,
+    isWildCardSearchDisabled: PropTypes.bool,
     isOpen: PropTypes.bool,
     results: PropTypes.arrayOf(PropTypes.object),
     isSearching: PropTypes.bool,
@@ -66,7 +67,7 @@ class SearchPanel extends React.PureComponent {
   };
 
   render() {
-    const { isDisabled, t, results, isSearching, noResult } = this.props;
+    const { isDisabled, t, results, isSearching, noResult, isWildCardSearchDisabled } = this.props;
 
     if (isDisabled) {
       return null;
@@ -82,7 +83,7 @@ class SearchPanel extends React.PureComponent {
           img="ic_close_black_24px"
           onClick={this.onClickClose}
         />
-        <div className="results">
+        <div className={`results ${isWildCardSearchDisabled ? '' : 'wild-card-visible'}`}>
           {isSearching && <div className="info">{t('message.searching')}</div>}
           {noResult && <div className="info">{t('message.noResults')}</div>}
           {results.map((result, i) => {
@@ -107,6 +108,7 @@ class SearchPanel extends React.PureComponent {
 
 const mapStateToProps = state => ({
   isDisabled: selectors.isElementDisabled(state, 'searchPanel'),
+  isWildCardSearchDisabled: selectors.isElementDisabled(state, 'wildCardSearchOption'),
   isOpen: selectors.isElementOpen(state, 'searchPanel'),
   results: selectors.getResults(state),
   isSearching: selectors.isSearching(state),

--- a/src/components/SearchPanel/SearchPanel.scss
+++ b/src/components/SearchPanel/SearchPanel.scss
@@ -8,7 +8,11 @@
     flex: 1;
     overflow-y: auto;
     padding: 10px;
-    margin-top: 110px !important;
+    margin-top: 80px !important;
+
+    &.wild-card-visible {
+      margin-top: 110px !important;
+    }
   }
 
   .loader-wrapper {


### PR DESCRIPTION
Received a [support ticket ](https://support.pdftron.com/a/tickets/10205)requesting the ability to disable the wildcard search option in the search panel. It's not straightforward to do it purely in CSS by the customer so I have added it as a `data-element` that can be disabled. Tweaked some CSS to make sure spacing is consistent when this option is disabled. 

UPDATE:
- Also added `applyWatermark` as data-element (this was removed 20 days ago in [master](https://github.com/PDFTron/webviewer-ui/pull/432/files#diff-e401c1d7d855d5dd2d33eaf5b014ffecL543)
QA Steps:
Disable the `wildCardSearchOption` and `applyWatermark` in your env:
```
Webviewer({
  initialDoc: hashFile,
  path: '/lib',
  disabledElements: ['wildCardSearchOption', 'applyWatermark'],
  enableMeasurement: true,
}, document.getElementById('viewer')).then(instance => {
});
```

Run webviewer and open the search panel. Do a search and ensure search results don't overlap the checkboxes or you get weird behaviours.

Go to the print modal, ensure the `Apply watermark` button is gone.