### PR TITLE
[Bugfix] Redrawing signature on resize

### DIFF
--- a/src/components/SignatureModal/InkSignature/InkSignature.js
+++ b/src/components/SignatureModal/InkSignature/InkSignature.js
@@ -35,20 +35,9 @@ const InkSignature = ({
   }, []);
 
   useEffect(() => {
-    const canvas = canvasRef.current;
-
     if (dimension.height && dimension.width) {
-      const { width, height } = canvas.getBoundingClientRect();
-      const ctx = canvas.getContext('2d');
-
-      // we resize the canvas when the bounding box of its parent element changes so that signatures can be drawn correctly
-      // since the canvas will be cleared when the size changes, we grab the image data before resizing and use it to redraw afterwards
-      const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
-
-      canvas.width = width;
-      canvas.height = height;
-
-      ctx.putImageData(imageData, 0, 0);
+      const signatureTool = core.getTool('AnnotationCreateSignature');
+      signatureTool.resizeCanvas();
     }
   }, [dimension]);
 


### PR DESCRIPTION
I updated the logic for how we redraw the signature.  I move some of it into the core (since  the core has a reference to the canvas). The PR for the core is 730, and has been merge in. 

One thing that I wanted to ask (not sure if it's too late) was if it make sense to call the method "resizeCanvas", since it could also be called "SignatureCreateTool.resizeAndRefreshCanvas" or even "SignatureCreateTool.refreshCanvas".