### PR TITLE
Changed error modal for upcoming error info changes

### DIFF
--- a/src/components/ErrorModal/ErrorModal.js
+++ b/src/components/ErrorModal/ErrorModal.js
@@ -35,7 +35,7 @@ const ErrorModal = () => {
 
   useEffect(() => {
     const onError = error => {
-      error = error.detail || error.message;
+      error = error.detail.message || error.detail || error.message;
       let errorMessage;
 
       if (typeof error === 'string') {

--- a/src/components/ErrorModal/ErrorModal.js
+++ b/src/components/ErrorModal/ErrorModal.js
@@ -35,7 +35,7 @@ const ErrorModal = () => {
 
   useEffect(() => {
     const onError = error => {
-      error = error.detail.message || error.detail || error.message;
+      error = (error.detail && (error.detail.message || error.detail)) || error.message;
       let errorMessage;
 
       if (typeof error === 'string') {


### PR DESCRIPTION
The error message was changed from a string to an object in a PR in the core. The error modal will need to know how to get the message and display it by default.