### PR TITLE
[Bugfix] Thumbnail loading when using WebViewer server

### DIFF
--- a/src/components/Thumbnail/Thumbnail.js
+++ b/src/components/Thumbnail/Thumbnail.js
@@ -90,10 +90,15 @@ class Thumbnail extends React.PureComponent {
       const { current } = thumbContainer;
 
       core.loadThumbnailAsync(index, thumb => {
+        const currentThumbnail = current.querySelector('.page-image');
+        if (currentThumbnail) {
+          current.removeChild(currentThumbnail);
+        }
+
         thumb.className = 'page-image';
         thumb.style.maxWidth = `${THUMBNAIL_SIZE}px`;
         thumb.style.maxHeight = `${THUMBNAIL_SIZE}px`;
-        current.removeChild(current.querySelector('.page-image'));
+
         current.appendChild(thumb);
         if (this.props.updateAnnotations) {
           this.props.updateAnnotations(index);

--- a/src/components/Thumbnail/Thumbnail.js
+++ b/src/components/Thumbnail/Thumbnail.js
@@ -90,7 +90,7 @@ class Thumbnail extends React.PureComponent {
       const { current } = thumbContainer;
 
       core.loadThumbnailAsync(index, thumb => {
-        const currentThumbnail = current.querySelector('.page-image');
+        const currentThumbnail = current?.querySelector('.page-image');
         if (currentThumbnail) {
           current.removeChild(currentThumbnail);
         }


### PR DESCRIPTION
There seem to be a race condition where there is a layout change event that trigger before the initial thumbnail is loaded. This produced a `parameter 1 is not of type Node` error, I added a null check to fix this issue. To reproduce it you can use

```
Webviewer({
  // this error doesn't happen for every file but it seems to consistently fail for this file 
  initialDoc: 'https://pdftron.s3.amazonaws.com/files/Boro.pdf',
  pdftronServer: 'https://demo.pdftron.com/',
  path: '/lib',
})
```