### PR TITLE
[CHANGE] Added instance.Feature.PageNavigation that can be used to enable/disable all the ways that navigate the viewer to a different page

### DIFF
--- a/src/components/DocumentContainer/DocumentContainer.js
+++ b/src/components/DocumentContainer/DocumentContainer.js
@@ -15,6 +15,11 @@ import selectors from 'selectors';
 
 import './DocumentContainer.scss';
 
+let allowMouseWheelToNavigatePages = true;
+export const setAllowMouseWheelToNavigatePages = allow => {
+  allowMouseWheelToNavigatePages = allow;
+};
+
 class DocumentContainer extends React.PureComponent {
   static propTypes = {
     isLeftPanelOpen: PropTypes.bool,
@@ -115,7 +120,7 @@ class DocumentContainer extends React.PureComponent {
     if (e.metaKey || e.ctrlKey) {
       e.preventDefault();
       this.wheelToZoom(e);
-    } else if (!core.isContinuousDisplayMode()) {
+    } else if (!core.isContinuousDisplayMode() && allowMouseWheelToNavigatePages) {
       this.wheelToNavigatePages(e);
     }
   }

--- a/src/components/DocumentContainer/index.js
+++ b/src/components/DocumentContainer/index.js
@@ -1,3 +1,4 @@
-import DocumentContainer from './DocumentContainer';
+import DocumentContainer, { setAllowMouseWheelToNavigatePages } from './DocumentContainer';
 
+export { setAllowMouseWheelToNavigatePages };
 export default DocumentContainer;

--- a/src/constants/feature.js
+++ b/src/constants/feature.js
@@ -14,6 +14,7 @@
  * @property {string} Copy Ability to copy text or annotations use Ctrl/Cmd + C hotkeys or the copy button.
  * @property {string} ThumbnailMerging Ability to drag and drop a file into the thumbnail panel to merge
  * @property {string} ThumbnailReordering Ability to reorder pages using the thumbnail panel
+ * @property {string} PageNavigation Ability to navigate through pages using mouse wheel, arrow up/down keys and the swipe gesture.
  * @example
 WebViewer(...)
   .then(function(instance) {
@@ -38,4 +39,5 @@ export default {
   ThumbnailMerging: 'ThumbnailMerging',
   ThumbnailReordering: 'ThumbnailReordering',
   ThumbnailMultiselect: 'ThumbnailMultiselect',
+  PageNavigation: 'PageNavigation',
 };

--- a/src/helpers/TouchEventManager.js
+++ b/src/helpers/TouchEventManager.js
@@ -8,6 +8,7 @@ const TouchEventManager = {
   initialize(document, container) {
     this.document = document;
     this.container = container;
+    this.allowSwipe = true;
     this.allowHorizontalSwipe = true;
     this.allowVerticalSwipe = false;
     this.verticalMomentum = 0;
@@ -189,6 +190,7 @@ const TouchEventManager = {
       }
       case 'swipe': {
         if (
+          !this.allowSwipe ||
           this.isUsingAnnotationTools() ||
           core.getSelectedText().length ||
           core.getSelectedAnnotations().length


### PR DESCRIPTION
This is an attempt to address https://github.com/PDFTron/webviewer-ui/issues/401 and https://trello.com/c/pMfbUglx/645-new-api-to-override-mouse-wheel. This PR doesn't explicitly expose an API to disable mouse wheel, but I think in many cases if the customer wants to disable wheel then he probably wants to disable other ways that can change the page number.

To verify:
In console, do `instance.disableFeatures([instance.Feature.PageNavigation])`, and verify that the page number can't be changed by using wheel, the swiping gesture, arrow up and arrow down.