### PR TITLE
[Bugfix] Keyboard page scrolling fixes

### DIFF
--- a/src/components/DocumentContainer/DocumentContainer.js
+++ b/src/components/DocumentContainer/DocumentContainer.js
@@ -202,7 +202,7 @@ class DocumentContainer extends React.PureComponent {
 
     return (
       <div className={className} ref={this.container} data-element="documentContainer" onScroll={this.handleScroll} onTransitionEnd={this.onTransitionEnd}>
-        <div className="document" ref={this.document}></div>
+        <div className="document" ref={this.document} tabIndex="-1"></div>
       </div>
     );
   }

--- a/src/components/DocumentContainer/DocumentContainer.js
+++ b/src/components/DocumentContainer/DocumentContainer.js
@@ -9,6 +9,7 @@ import loadDocument from 'helpers/loadDocument';
 import getNumberOfPagesToNavigate from 'helpers/getNumberOfPagesToNavigate';
 import touchEventManager from 'helpers/TouchEventManager';
 import getHashParams from 'helpers/getHashParams';
+import setCurrentPage from 'helpers/setCurrentPage';
 import { getMinZoomLevel, getMaxZoomLevel } from 'constants/zoomFactors';
 import actions from 'actions';
 import selectors from 'selectors';
@@ -135,19 +136,17 @@ class DocumentContainer extends React.PureComponent {
   }
 
   pageUp = () => {
-    const { currentPage, displayMode } = this.props;
+    const { currentPage } = this.props;
     const { scrollHeight, clientHeight } = this.container.current;
-    const newPage = currentPage - getNumberOfPagesToNavigate(displayMode);
 
-    core.setCurrentPage(Math.max(newPage, 1));
+    setCurrentPage(currentPage - getNumberOfPagesToNavigate());
     this.container.current.scrollTop = scrollHeight - clientHeight;
   }
 
   pageDown = () => {
-    const { currentPage, displayMode, totalPages } = this.props;
-    const newPage = currentPage + getNumberOfPagesToNavigate(displayMode);
+    const { currentPage } = this.props;
 
-    core.setCurrentPage(Math.min(newPage, totalPages));
+    setCurrentPage(currentPage + getNumberOfPagesToNavigate());
   }
 
   wheelToZoom = e => {

--- a/src/helpers/TouchEventManager.js
+++ b/src/helpers/TouchEventManager.js
@@ -207,8 +207,7 @@ const TouchEventManager = {
 
         const currentPage = core.getCurrentPage();
         const totalPages = core.getTotalPages();
-        const displayMode = core.getDisplayMode();
-        const numberOfPagesToNavigate = getNumberOfPagesToNavigate(displayMode);
+        const numberOfPagesToNavigate = getNumberOfPagesToNavigate();
 
         const isFirstPage = currentPage === 1;
         const isLastPage = currentPage === totalPages;

--- a/src/helpers/getNumberOfPagesToNavigate.js
+++ b/src/helpers/getNumberOfPagesToNavigate.js
@@ -1,4 +1,6 @@
-export default displayMode => {
+import core from 'core';
+
+export default () => {
   const mapDisplayModeToNumberOfPages = {
     Single: 1,
     Continuous: 1,
@@ -8,5 +10,5 @@ export default displayMode => {
     Cover: 2,
   };
 
-  return mapDisplayModeToNumberOfPages[displayMode];
+  return mapDisplayModeToNumberOfPages[core.getDisplayMode()];
 };

--- a/src/helpers/getNumberOfPagesToNavigate.js
+++ b/src/helpers/getNumberOfPagesToNavigate.js
@@ -1,8 +1,11 @@
 export default displayMode => {
   const mapDisplayModeToNumberOfPages = {
     Single: 1,
+    Continuous: 1,
     Facing: 2,
+    FacingContinuous: 2,
     CoverFacing: 2,
+    Cover: 2,
   };
 
   return mapDisplayModeToNumberOfPages[displayMode];

--- a/src/helpers/hotkeysManager.js
+++ b/src/helpers/hotkeysManager.js
@@ -10,7 +10,6 @@ import createTextAnnotationAndSelect from 'helpers/createTextAnnotationAndSelect
 import { isMobile } from 'helpers/device';
 import isFocusingElement from 'helpers/isFocusingElement';
 import getNumberOfPagesToNavigate from 'helpers/getNumberOfPagesToNavigate';
-import LayoutMode from 'constants/layoutMode';
 import actions from 'actions';
 import selectors from 'selectors';
 

--- a/src/helpers/hotkeysManager.js
+++ b/src/helpers/hotkeysManager.js
@@ -10,6 +10,7 @@ import createTextAnnotationAndSelect from 'helpers/createTextAnnotationAndSelect
 import { isMobile } from 'helpers/device';
 import isFocusingElement from 'helpers/isFocusingElement';
 import getNumberOfPagesToNavigate from 'helpers/getNumberOfPagesToNavigate';
+import setCurrentPage from 'helpers/setCurrentPage';
 import actions from 'actions';
 import selectors from 'selectors';
 
@@ -241,37 +242,20 @@ WebViewer(...)
       pageup: e => {
         e.preventDefault();
 
-        const currPageNumber = core.getCurrentPage();
-        const pageDecrease = getNumberOfPagesToNavigate(core.getDisplayMode());
-        const nextPageNumber = currPageNumber - pageDecrease < 1 ? 1 : currPageNumber - pageDecrease;
-
-        if (nextPageNumber !== currPageNumber) {
-          core.setCurrentPage(nextPageNumber);
-        }
+        setCurrentPage(core.getCurrentPage() - getNumberOfPagesToNavigate());
       },
       pagedown: e => {
         e.preventDefault();
 
-        const currPageNumber = core.getCurrentPage();
-        const totalPageNumber = core.getTotalPages();
-        const pageIncrease = getNumberOfPagesToNavigate(core.getDisplayMode());
-        const nextPageNumber = currPageNumber + pageIncrease > totalPageNumber ? totalPageNumber : currPageNumber + pageIncrease;
-
-        if (nextPageNumber !== currPageNumber) {
-          core.setCurrentPage(nextPageNumber);
-        }
+        setCurrentPage(core.getCurrentPage() + getNumberOfPagesToNavigate());
       },
       up: () => {
         // do not call preventDefault else it will prevent scrolling
         const scrollViewElement = core.getScrollViewElement();
         const { scrollHeight, clientHeight } = scrollViewElement;
         const reachedTop = scrollViewElement.scrollTop === 0;
-        const currPageNumber = core.getCurrentPage();
-        if (reachedTop && currPageNumber > 1) {
-          const pageDecrease = getNumberOfPagesToNavigate(core.getDisplayMode());
-          const nextPageNumber = currPageNumber - pageDecrease < 1 ? 1 : currPageNumber - pageDecrease;
-
-          core.setCurrentPage(nextPageNumber);
+        if (reachedTop) {
+          setCurrentPage(core.getCurrentPage() - getNumberOfPagesToNavigate());
           // set the scrollbar to be at the bottom of the page
           scrollViewElement.scrollTop = scrollHeight - clientHeight;
         }
@@ -281,13 +265,8 @@ WebViewer(...)
         const scrollViewElement = core.getScrollViewElement();
         const { scrollTop, clientHeight, scrollHeight } = scrollViewElement;
         const reachedBottom = Math.abs(scrollTop + clientHeight - scrollHeight) <= 1;
-        const currPageNumber = core.getCurrentPage();
-        const totalPageNumber = core.getTotalPages();
-        if (reachedBottom && currPageNumber < totalPageNumber) {
-          const pageIncrease = getNumberOfPagesToNavigate(core.getDisplayMode());
-          const nextPageNumber = currPageNumber + pageIncrease > totalPageNumber ? totalPageNumber : currPageNumber + pageIncrease;
-
-          core.setCurrentPage(nextPageNumber);
+        if (reachedBottom) {
+          setCurrentPage(core.getCurrentPage() + getNumberOfPagesToNavigate());
         }
       },
       space: {

--- a/src/helpers/hotkeysManager.js
+++ b/src/helpers/hotkeysManager.js
@@ -268,7 +268,7 @@ WebViewer(...)
         const { scrollHeight, clientHeight } = scrollViewElement;
         const reachedTop = scrollViewElement.scrollTop === 0;
         const currPageNumber = core.getCurrentPage();
-        if (!this.isContinuous() && reachedTop && currPageNumber > 1) {
+        if (reachedTop && currPageNumber > 1) {
           const pageDecrease = getNumberOfPagesToNavigate(core.getDisplayMode());
           const nextPageNumber = currPageNumber - pageDecrease < 1 ? 1 : currPageNumber - pageDecrease;
 
@@ -284,7 +284,7 @@ WebViewer(...)
         const reachedBottom = Math.abs(scrollTop + clientHeight - scrollHeight) <= 1;
         const currPageNumber = core.getCurrentPage();
         const totalPageNumber = core.getTotalPages();
-        if (!this.isContinuous() && reachedBottom && currPageNumber < totalPageNumber) {
+        if (reachedBottom && currPageNumber < totalPageNumber) {
           const pageIncrease = getNumberOfPagesToNavigate(core.getDisplayMode());
           const nextPageNumber = currPageNumber + pageIncrease > totalPageNumber ? totalPageNumber : currPageNumber + pageIncrease;
 
@@ -454,19 +454,6 @@ WebViewer(...)
     };
 
     return map[toolName];
-  },
-  isContinuous() {
-    let isContinuous = false;
-
-    switch (core.getDisplayMode()) {
-      case LayoutMode.Cover:
-      case LayoutMode.Continuous:
-      case LayoutMode.FacingContinuous:
-        isContinuous = true;
-        break;
-    }
-
-    return isContinuous;
   },
 };
 

--- a/src/helpers/setCurrentPage.js
+++ b/src/helpers/setCurrentPage.js
@@ -1,0 +1,13 @@
+import core from 'core';
+
+export default nextPageNumber => {
+  const totalPageNumber = core.getTotalPages();
+  const currPageNumber = core.getCurrentPage();
+
+  let nextPage = Math.min(totalPageNumber, nextPageNumber);
+  nextPage = Math.max(1, nextPageNumber);
+
+  if (nextPage !== currPageNumber) {
+    core.setCurrentPage(nextPage);
+  }
+};


### PR DESCRIPTION
I fix a few issues with page scrolling with the arrow keys and the pageup/pagedown buttons. Problems I fix were

- Up/Down arrow keys will stop working when switching pages if you are zoomed in 
- For non-continuous mode with 2 pages, the mouse scroll wheel will go up and down while the up and down arrow keys will switch between right and left

Note sure if we want:
Should page up/down key change one page at a time when displaying two pages? When the user is zoomed out it doesn't make sense to do one page at time since going from page 3 to 4 might not do anything (if they are both displayed). However when WebViewer is zoomed in, the page up/down key will go from the left to right which make sense but feel unnatural since most of the time page up/down only does vertical moment.
