### PR TITLE
[Bugfix] fixes the issue for invalid regex in search

### DIFF
--- a/src/components/SearchOverlay/SearchOverlay.js
+++ b/src/components/SearchOverlay/SearchOverlay.js
@@ -114,9 +114,8 @@ class SearchOverlay extends React.PureComponent {
   }
 
   searchFailed = error => {
-    const { setIsSearching, setNoResult, setSearchError } = this.props;
+    const { setIsSearching, setSearchError } = this.props;
     setIsSearching(false);
-    setNoResult(true);
     if (error && error.message) {
       setSearchError(error.message);
     }

--- a/src/components/SearchOverlay/SearchOverlay.js
+++ b/src/components/SearchOverlay/SearchOverlay.js
@@ -54,6 +54,7 @@ class SearchOverlay extends React.PureComponent {
     setIsProgrammaticSearch: PropTypes.func.isRequired,
     setIsProgrammaticSearchFull: PropTypes.func.isRequired,
     t: PropTypes.func.isRequired,
+    setSearchError: PropTypes.func.isRequired,
   }
 
   constructor() {
@@ -101,6 +102,23 @@ class SearchOverlay extends React.PureComponent {
     if (searchOverlayClosed) {
       this.props.closeElement('searchPanel');
       this.clearSearchResults();
+    }
+  }
+
+  componentDidMount() {
+    core.addEventListener('searchFailed', this.searchFailed);
+  }
+
+  componentWillUnmount() {
+    core.removeEventListener('searchFailed', this.searchFailed);
+  }
+
+  searchFailed = error => {
+    const { setIsSearching, setNoResult, setSearchError } = this.props;
+    setIsSearching(false);
+    setNoResult(true);
+    if (error && error.message) {
+      setSearchError(error.message);
     }
   }
 
@@ -441,6 +459,7 @@ const mapDispatchToProps = {
   setWholeWord: actions.setWholeWord,
   setWildcard: actions.setWildcard,
   setNoResult: actions.setNoResult,
+  setSearchError: actions.setSearchError,
   setIsProgrammaticSearch: actions.setIsProgrammaticSearch,
   setIsProgrammaticSearchFull: actions.setIsProgrammaticSearchFull,
 };

--- a/src/components/SearchPanel/SearchPanel.js
+++ b/src/components/SearchPanel/SearchPanel.js
@@ -26,6 +26,7 @@ class SearchPanel extends React.PureComponent {
     setActiveResultIndex: PropTypes.func.isRequired,
     closeElement: PropTypes.func.isRequired,
     t: PropTypes.func.isRequired,
+    errorMessage: PropTypes.string,
   };
 
   componentDidUpdate(prevProps) {
@@ -67,7 +68,7 @@ class SearchPanel extends React.PureComponent {
   };
 
   render() {
-    const { isDisabled, t, results, isSearching, noResult, isWildCardSearchDisabled } = this.props;
+    const { isDisabled, t, results, isSearching, noResult, isWildCardSearchDisabled, errorMessage } = this.props;
 
     if (isDisabled) {
       return null;
@@ -86,6 +87,7 @@ class SearchPanel extends React.PureComponent {
         <div className={`results ${isWildCardSearchDisabled ? '' : 'wild-card-visible'}`}>
           {isSearching && <div className="info">{t('message.searching')}</div>}
           {noResult && <div className="info">{t('message.noResults')}</div>}
+          {errorMessage && <div className="warn">{errorMessage}</div>}
           {results.map((result, i) => {
             const prevResult = i === 0 ? results[0] : results[i - 1];
 
@@ -113,6 +115,7 @@ const mapStateToProps = state => ({
   results: selectors.getResults(state),
   isSearching: selectors.isSearching(state),
   noResult: selectors.isNoResult(state),
+  errorMessage: selectors.getSearchErrorMessage(state),
 });
 
 const mapDispatchToProps = {

--- a/src/components/SearchPanel/SearchPanel.scss
+++ b/src/components/SearchPanel/SearchPanel.scss
@@ -25,6 +25,13 @@
     padding: 15px 0;
     font-size: 0.8em;
   }
+  .warn {
+    padding: 15px 0;
+    font-size: 0.8em;
+  }
+  .warn::before {
+    content: "⚠️ ";
+  }
 
   .close-btn {
     @include mobile {

--- a/src/core/eventListener.js
+++ b/src/core/eventListener.js
@@ -32,6 +32,7 @@ const getEventToObjectMap = () => {
     mouseRightUp: window.docViewer,
     pageComplete: window.docViewer,
     searchInProgress: window.docViewer,
+    searchFailed: window.docViewer,
     textSelected: window.docViewer,
     beginRendering: window.docViewer,
     finishedRendering: window.docViewer,

--- a/src/redux/actions/internalActions.js
+++ b/src/redux/actions/internalActions.js
@@ -339,6 +339,10 @@ export const setNoResult = noResult => ({
   type: 'SET_NO_RESULT',
   payload: { noResult },
 });
+export const setSearchError = errorMessage => ({
+  type: 'SET_SEARCH_ERROR',
+  payload: { errorMessage },
+});
 export const resetSearch = () => ({ type: 'RESET_SEARCH', payload: {} });
 export const setIsProgrammaticSearch = isProgrammaticSearch => ({
   type: 'SET_IS_PROG_SEARCH',

--- a/src/redux/reducers/searchReducer.js
+++ b/src/redux/reducers/searchReducer.js
@@ -121,6 +121,12 @@ export default initialState => (state = initialState, action) => {
         noResult: payload.noResult,
       };
     }
+    case 'SET_SEARCH_ERROR': {
+      return {
+        ...state,
+        errorMessage: payload.errorMessage,
+      };
+    }
     case 'RESET_SEARCH': {
       return {
         ...initialState,

--- a/src/redux/selectors/exposedSelectors.js
+++ b/src/redux/selectors/exposedSelectors.js
@@ -204,6 +204,8 @@ export const isSearching = state => state.search.isSearching;
 
 export const isNoResult = state => state.search.noResult;
 
+export const getSearchErrorMessage = state => state.search.errorMessage;
+
 export const isProgrammaticSearch = state => state.search.isProgrammaticSearch;
 
 export const isProgrammaticSearchFull = state =>


### PR DESCRIPTION
<!--
  Before creating this PR:

  1. Set title of PR:
      [Feature] A new feature
      [Build] Changes to build files
      [Bugfix] A fix

     If those don't cover your PR, choose any tag that makes sense.

  2. If this is a WIP, add the 🚧 emoji at the beginning, and open a DRAFT PR.
     See: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

### Description

Fixes the issue for invalid regex in search

### To verify
Regex in Chrome 
```js
readerControl.searchTextFull('(?<=(PDF\\s))(\\w+)', { regex: true }); // Valid 
readerControl.searchTextFull('(?=(PDF\\s)(\\w+)', { regex: true }); // Invlaid
```

Regex in Firefox
```js
readerControl.searchTextFull('(?<=(PDF\\s))(\\w+)', { regex: true }); // Invalid
readerControl.searchTextFull('(?=(PDF\\s))(\\w+)', { regex: true }); // Valid
readerControl.searchTextFull('(?=(PDF\\s)(\\w+)', { regex: true }); // Invalid
```

<!-- Describe how a reviewer could verify if your code works. -->
<img width="298" alt="Screen Shot 2020-02-20 at 9 13 07 AM" src="https://user-images.githubusercontent.com/1588234/74960681-a3325600-53c1-11ea-8591-6781caa0bed5.png">
<img width="298" alt="Screen Shot 2020-02-20 at 9 14 39 AM" src="https://user-images.githubusercontent.com/1588234/74960718-a6c5dd00-53c1-11ea-8d76-6ccaa08952c2.png">

### Related issues

<!-- Or write "None" -->

Fixes https://trello.com/c/Sk4OW3BR/767-invalid-regex-in-search-throws-error-and-gets-stuck
