### PR TITLE
Exposes setSelectedPageThumbnails for Feature.ThumbnailMultiselect

### DIFF
--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -101,6 +101,7 @@ import setPageLabels from './setPageLabels';
 import setPrintQuality from './setPrintQuality';
 import setReadOnly from './setReadOnly';
 import setSelectedTab from './setSelectedTab';
+import setSelectedThumbnailPageNumbers from './setSelectedThumbnailPageNumbers';
 import setShowSideWindow from './setShowSideWindow';
 import setSideWindowVisibility from './setSideWindowVisibility';
 import setSortNotesBy from './setSortNotesBy';
@@ -199,6 +200,7 @@ export default store => {
     setCustomMeasurementOverlayInfo: setCustomMeasurementOverlayInfo(store),
     setSignatureFonts: setSignatureFonts(store),
     setSelectedTab: setSelectedTab(store),
+    setSelectedThumbnailPageNumbers: setSelectedThumbnailPageNumbers(store),
     getSelectedThumbnailPageNumbers: getSelectedThumbnailPageNumbers(store),
 
     // undocumented and deprecated, to be removed in 7.0

--- a/src/apis/setSelectedThumbnailPageNumbers.js
+++ b/src/apis/setSelectedThumbnailPageNumbers.js
@@ -1,0 +1,16 @@
+/**
+ * Sets the currently selected pages
+ * @method WebViewerInstance#setSelectedThumbnailPageNumbers
+ * @param {Array.<number>} selectedThumbnailPageNumbers an array of select page numbers
+ * @example // 6.0 and after
+WebViewer(...)
+  .then(function(instance) {
+    instance.setSelectedThumbnailPageNumbers([1, 2, 3]);
+  });
+ */
+
+import actions from 'actions';
+
+export default store => selectedThumbnailPageNumbers => {
+  store.dispatch(actions.setSelectedPageThumbnails(selectedThumbnailPageNumbers));
+};


### PR DESCRIPTION
The selected thumbnails needs to be corrected after pages are moved or removed. ThumbnailsPanel is doing this internally, but that action is not exposed for external users of the WebViewer React app.