### PR TITLE
[Update] Thumbnail multi drag and cleanup

### DIFF
--- a/src/components/LeftPanel/LeftPanel.js
+++ b/src/components/LeftPanel/LeftPanel.js
@@ -36,6 +36,16 @@ const LeftPanel = () => {
     }
   }, [dispatch, isOpen]);
 
+  const onDrop = e => {
+    // this is mainly for the thumbnail panel, to prevent the broswer from loading a document that dropped in
+    e.preventDefault();
+  };
+
+  const onDragOver = e => {
+    // when dragging over the "LeftPanel", change the cursor to "Move" from "Copy"
+    e.preventDefault();
+  };
+
   const getDisplay = panel => (panel === activePanel ? 'flex' : 'none');
   // IE11 will use javascript for controlling width, other broswers will use CSS variables
   const style = isIE11 && leftPanelWidth ? { width: leftPanelWidth } : { };
@@ -48,6 +58,8 @@ const LeftPanel = () => {
         open: isOpen,
         closed: !isOpen,
       })}
+      onDrop={onDrop}
+      onDragOver={onDragOver}
       data-element="leftPanel"
       style={style}
     >

--- a/src/components/ThumbnailControls/ThumbnailControls.js
+++ b/src/components/ThumbnailControls/ThumbnailControls.js
@@ -43,9 +43,7 @@ const ThumbnailControls = ({
       message,
       title,
       confirmBtnText,
-      onConfirm: () => core.removePages([index + 1]).then(() => {
-        dispatch(actions.deletePageIndex(index));
-      }),
+      onConfirm: () => core.removePages([index + 1]),
     };
 
     if (core.getDocumentViewer().getPageCount() === 1) {

--- a/src/components/ThumbnailsPanel/ThumbnailsPanel.js
+++ b/src/components/ThumbnailsPanel/ThumbnailsPanel.js
@@ -78,11 +78,10 @@ class ThumbnailsPanel extends React.PureComponent {
   }
 
   onDragEnd = () => {
-    const { currentPage, selectedPageIndexes, setSelectedPageThumbnails, isThumbnailReorderingEnabled } = this.props;
+    const { currentPage, selectedPageIndexes, isThumbnailReorderingEnabled } = this.props;
     const { draggingOverPageIndex, isDraggingToPreviousPage } = this.state;
     if (isThumbnailReorderingEnabled && draggingOverPageIndex !== null) {
       const targetPageNumber = isDraggingToPreviousPage ? draggingOverPageIndex + 1 : draggingOverPageIndex + 2;
-      const pageNumberIncreased = currentPage < targetPageNumber;
 
       let pageNumbersToMove = [currentPage];
       if (this.isDraggingGroup) {
@@ -90,24 +89,7 @@ class ThumbnailsPanel extends React.PureComponent {
       }
 
       this.afterMovePageNumber = targetPageNumber - pageNumbersToMove.filter(p => p < targetPageNumber).length;
-      core.movePages(pageNumbersToMove, targetPageNumber).then(() => {
-        const currentPageIndex = currentPage - 1;
-        const targetPageIndex = this.afterMovePageNumber - 1;
-
-        // update selected pages affected by the move, exclude the page that was moved
-        let updateSelectedPageIndexes = selectedPageIndexes.filter(pageIndex => !pageNumbersToMove.includes(pageIndex + 1));
-        if (pageNumberIncreased) {
-          updateSelectedPageIndexes = updateSelectedPageIndexes.map(p => (p > currentPageIndex && p <= targetPageIndex ? p - 1 : p));
-        } else {
-          updateSelectedPageIndexes = updateSelectedPageIndexes.map(p => (p < currentPageIndex && p >= targetPageIndex ? p + 1 : p));
-        }
-
-        if (selectedPageIndexes.includes(currentPageIndex)) {
-          updateSelectedPageIndexes.push(...pageNumbersToMove.map((val, index) => targetPageIndex + index));
-        }
-
-        setSelectedPageThumbnails(updateSelectedPageIndexes);
-      });
+      core.movePages(pageNumbersToMove, targetPageNumber);
     }
 
     this.setState({ draggingOverPageIndex: null });
@@ -225,7 +207,7 @@ class ThumbnailsPanel extends React.PureComponent {
     }
 
     if (changes.moved) {
-      updatedPagesIndexes = updatedPagesIndexes.map(pageIndex => changes.moved[pageIndex + 1] - 1 ? changes.moved[pageIndex + 1] - 1 : pageIndex);
+      updatedPagesIndexes = updatedPagesIndexes.map(pageIndex => changes.moved[pageIndex + 1]? changes.moved[pageIndex + 1] - 1 : pageIndex);
     }
 
     setSelectedPageThumbnails(updatedPagesIndexes);

--- a/src/components/ThumbnailsPanel/ThumbnailsPanel.js
+++ b/src/components/ThumbnailsPanel/ThumbnailsPanel.js
@@ -77,14 +77,15 @@ class ThumbnailsPanel extends React.PureComponent {
     });
   }
 
-  onDragEnd = () => {
+  onDragEnd = e => {
     const { currentPage, selectedPageIndexes, isThumbnailReorderingEnabled } = this.props;
     const { draggingOverPageIndex, isDraggingToPreviousPage } = this.state;
     if (isThumbnailReorderingEnabled && draggingOverPageIndex !== null) {
       const targetPageNumber = isDraggingToPreviousPage ? draggingOverPageIndex + 1 : draggingOverPageIndex + 2;
 
       let pageNumbersToMove = [currentPage];
-      if (this.isDraggingGroup) {
+      // for PC "ctrlKey" is true for the "onDrop" event while for Mac, it true for "onDragEnd" 
+      if (this.isDraggingGroup || (e.ctrlKey || e.metaKey) ) {
         pageNumbersToMove = selectedPageIndexes.map(i => i + 1);
       }
 

--- a/src/components/ThumbnailsPanel/ThumbnailsPanel.js
+++ b/src/components/ThumbnailsPanel/ThumbnailsPanel.js
@@ -84,8 +84,7 @@ class ThumbnailsPanel extends React.PureComponent {
       const targetPageNumber = isDraggingToPreviousPage ? draggingOverPageIndex + 1 : draggingOverPageIndex + 2;
 
       let pageNumbersToMove = [currentPage];
-      // for PC "ctrlKey" is true for the "onDrop" event while for Mac, it true for "onDragEnd" 
-      if (this.isDraggingGroup || (e.ctrlKey || e.metaKey) ) {
+      if (this.isDraggingGroup) {
         pageNumbersToMove = selectedPageIndexes.map(i => i + 1);
       }
 
@@ -107,6 +106,9 @@ class ThumbnailsPanel extends React.PureComponent {
     // 'preventDefault' to prevent opening pdf dropped in and 'stopPropagation' to keep parent from opening pdf
     e.preventDefault();
     e.stopPropagation();
+
+    // for Mac "metaKey" is only true during onDragOver
+    this.isDraggingGroup = e.ctrlKey || e.metaKey;
 
     const { numberOfColumns } = this.state;
     const { isThumbnailReorderingEnabled, isThumbnailMergingEnabled } = this.props;
@@ -151,11 +153,6 @@ class ThumbnailsPanel extends React.PureComponent {
     const { isThumbnailMergingEnabled, dispatch } = this.props;
     const { draggingOverPageIndex, isDraggingToPreviousPage } = this.state;
     const { files } = e.dataTransfer;
-
-    this.isDraggingGroup = false;
-    if (e.ctrlKey || e.metaKey) {
-      this.isDraggingGroup = true;
-    }
 
     if (isThumbnailMergingEnabled && files.length) {
       const file = files[0];

--- a/src/redux/actions/exposedActions.js
+++ b/src/redux/actions/exposedActions.js
@@ -173,10 +173,6 @@ export const setSelectedPageThumbnails = (selectedThumbnailPageIndexes = []) => 
   type: 'SET_SELECTED_THUMBNAIL_PAGE_INDEXES',
   payload: { selectedThumbnailPageIndexes },
 });
-export const deletePageIndex = pageIndexDeleted => ({
-  type: 'REMOVE_PAGE_INDEX',
-  payload: { pageIndexDeleted },
-});
 export const setSwipeOrientation = swipeOrientation => ({
   type: 'SET_SWIPE_ORIENTATION',
   payload: { swipeOrientation },

--- a/src/redux/reducers/viewerReducer.js
+++ b/src/redux/reducers/viewerReducer.js
@@ -171,10 +171,6 @@ export default initialState => (state = initialState, action) => {
       return { ...state, pageLabels: [...payload.pageLabels] };
     case 'SET_SELECTED_THUMBNAIL_PAGE_INDEXES':
       return { ...state, selectedThumbnailPageIndexes: payload.selectedThumbnailPageIndexes };
-    case 'REMOVE_PAGE_INDEX':
-      return { ...state,
-        selectedThumbnailPageIndexes: state.selectedThumbnailPageIndexes.filter(p => p !== payload.pageIndexDeleted).map(p => (p < payload.pageIndexDeleted ? p : p - 1)),
-      };
     case 'SET_COLOR_PALETTE': {
       const { colorMapKey, colorPalette } = payload;
       return {


### PR DESCRIPTION
This pull request is for allowing users to hold "Ctrl" to drag and drop multiple thumbnails at once (will be needed for the next update).  Also I clean up the code by using the "LayoutChanged" event to updated the selected thumbnails. 