### PR TITLE
[Bugfix] Allow tooltip to work for customElement headers

### DIFF
--- a/src/components/CustomElement/CustomElement.js
+++ b/src/components/CustomElement/CustomElement.js
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 
+import Tooltip from 'components/Tooltip';
 import selectors from 'selectors';
 
 import './CustomElement.scss';
@@ -13,6 +14,7 @@ const propTypes = {
   display: PropTypes.string,
   render: PropTypes.func.isRequired,
   mediaQueryClassName: PropTypes.string,
+  title: PropTypes.string,
 };
 
 const CustomElement = ({
@@ -21,9 +23,11 @@ const CustomElement = ({
   display,
   render,
   mediaQueryClassName,
+  title,
 }) => {
   const [reactComponent, setReactComponent] = useState(null);
   const wrapperRef = useRef();
+  const toolTipWrapperRef = useRef();
   const isDisabled = useSelector(state => selectors.isElementDisabled(state, dataElement));
 
   useEffect(() => {
@@ -48,7 +52,7 @@ const CustomElement = ({
       const element = render();
 
       if (isDOMElement(element)) {
-        const wrapperElement = wrapperRef.current;
+        const wrapperElement = toolTipWrapperRef ? toolTipWrapperRef.current : wrapperRef.current;
 
         while (wrapperElement.firstChild) {
           wrapperElement.removeChild(wrapperElement.firstChild);
@@ -64,7 +68,11 @@ const CustomElement = ({
     }
   }, [isDisabled, render]);
 
-  return isDisabled ? null : (
+  if (isDisabled) {
+    return null;
+  } 
+
+  const children = (
     <div
       className={classNames({
         [className]: !!className,
@@ -77,6 +85,8 @@ const CustomElement = ({
       {reactComponent}
     </div>
   );
+
+  return title ? (<Tooltip content={title} ref={toolTipWrapperRef}>{children}</Tooltip>) : children;
 };
 
 CustomElement.propTypes = propTypes;

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useLayoutEffect } from 'react';
+import React, { useState, useRef, useEffect, useLayoutEffect, forwardRef } from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
@@ -12,9 +12,24 @@ const propTypes = {
   content: PropTypes.string,
 };
 
-const Tooltip = ({ content = '', children }) => {
+function useCombinedRefs(forwardedRef) {
+  // this is mainly for 'CustomElement' because they might need to update the DOM when rendering 
+  const targetRef = useRef();
+
+  useEffect(() => {
+    if (!forwardedRef) {
+      return
+    }
+
+    forwardedRef.current = targetRef.current;
+  }, [forwardedRef]);
+
+  return targetRef;
+}
+
+const Tooltip = forwardRef( ({ content = '', children }, forwardedRef) => {
   const timeoutRef = useRef(null);
-  const childRef = useRef(null);
+  const childRef = forwardedRef ? useCombinedRefs(forwardedRef) : useRef(null);
   const tooltipRef = useRef(null);
   const [show, setShow] = useState(false);
   const [opacity, setOpacity] = useState(0);
@@ -141,7 +156,7 @@ const Tooltip = ({ content = '', children }) => {
         )}
     </React.Fragment>
   );
-};
+});
 
 Tooltip.propTypes = propTypes;
 

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -12,24 +12,10 @@ const propTypes = {
   content: PropTypes.string,
 };
 
-function useCombinedRefs(forwardedRef) {
-  // this is mainly for 'CustomElement' because they might need to update the DOM when rendering 
-  const targetRef = useRef();
-
-  useEffect(() => {
-    if (!forwardedRef) {
-      return
-    }
-
-    forwardedRef.current = targetRef.current;
-  }, [forwardedRef]);
-
-  return targetRef;
-}
-
 const Tooltip = forwardRef( ({ content = '', children }, forwardedRef) => {
   const timeoutRef = useRef(null);
-  const childRef = forwardedRef ? useCombinedRefs(forwardedRef) : useRef(null);
+  const childRef = forwardedRef ? forwardedRef : useRef(null);
+
   const tooltipRef = useRef(null);
   const [show, setShow] = useState(false);
   const [opacity, setOpacity] = useState(0);


### PR DESCRIPTION
This fix allows tooltip to work for customElements. So you can do something like 
```
Webviewer({}, document.getElementById('viewer')).then(instance => {
  var checkboxLabelElement = {
    type: 'customElement',
    title: 'Tooltip popup message',
    render: function() {
      const label = document.createElement('label');
      label.innerHTML = 'Custom Label';
      return label;
    },
  };

  instance.setHeaderItems(function(header) {
    var items = header.getItems();
    items.splice(items.length - 2, 0, checkboxLabelElement);
    header.update(items);
  });
/*
```

and you'll get the tooltip when you hover over the element. 

Also for "intialState.js" we can add a title for "zoomOverlayButton" and maybe clean up "signatureToolButton" (SignatureToolButton.js is adding the tooltip for signature).