### PR TITLE
[Bugfix] Hide links when other annotations are disabled

### DIFF
--- a/src/event-listeners/onUpdateAnnotationPermission.js
+++ b/src/event-listeners/onUpdateAnnotationPermission.js
@@ -11,6 +11,7 @@ export default store => () => {
   const elements = [
     'annotationPopup',
     'toolsButton',
+    'linkButton',
   ];
 
   if (isReadOnly) {

--- a/src/helpers/createFeatureAPI.js
+++ b/src/helpers/createFeatureAPI.js
@@ -28,6 +28,7 @@ export default (enable, store) => features => {
         'notesPanel',
         'notesPanelButton',
         'toolsButton',
+        'linkButton',
       ],
       fn: () => {
         if (enable) {


### PR DESCRIPTION
This PR fix an issue where the "link" button is appearing when annotations are disabled. 

![image](https://user-images.githubusercontent.com/45575633/77111401-826f1780-69e4-11ea-9154-25694426ad57.png)

You can test with:
`readerControl.setReadOnly(true)`
`readerControl.disableAnnotations()`
