### PR TITLE
Fix issue with annotations still appearing in downloaded PDF

### DIFF
--- a/src/helpers/downloadPdf.js
+++ b/src/helpers/downloadPdf.js
@@ -18,59 +18,57 @@ export default (dispatch, options = {}) => {
 
   dispatch(actions.openElement('loadingModal'));
 
-  return core
-    .exportAnnotations()
-    .then(xfdfString => {
-      if (includeAnnotations) {
-        options.xfdfString = options.xfdfString || xfdfString;
+  const annotationsPromise = (includeAnnotations && !options.xfdfString) ? core.exportAnnotations() : Promise.resolve('<xfdf></xfdf>');
+
+  return annotationsPromise.then(xfdfString => {
+    options.xfdfString = options.xfdfString || xfdfString;
+
+    const getDownloadFilename = (name, extension) => {
+      if (name.slice(-extension.length).toLowerCase() !== extension) {
+        name += extension;
       }
+      return name;
+    };
 
-      const getDownloadFilename = (name, extension) => {
-        if (name.slice(-extension.length).toLowerCase() !== extension) {
-          name += extension;
-        }
-        return name;
-      };
+    const downloadName = getDownloadFilename(filename, '.pdf');
+    const doc = core.getDocument();
 
-      const downloadName = getDownloadFilename(filename, '.pdf');
-      const doc = core.getDocument();
-
-      if (externalURL) {
-        const downloadIframe =
-          document.getElementById('download-iframe') ||
-          document.createElement('iframe');
-        downloadIframe.width = 0;
-        downloadIframe.height = 0;
-        downloadIframe.id = 'download-iframe';
-        downloadIframe.src = null;
-        document.body.appendChild(downloadIframe);
-        downloadIframe.src = externalURL;
-        dispatch(actions.closeElement('loadingModal'));
-        fireEvent('finishedSavingPDF');
-      } else {
-        return doc.getFileData(options).then(
-          data => {
-            const arr = new Uint8Array(data);
-            let file;
-
-            if (isIE) {
-              file = new Blob([arr], { type: 'application/pdf' });
-            } else {
-              file = new File([arr], downloadName, { type: 'application/pdf' });
-            }
-
-            saveAs(file, downloadName);
-            dispatch(actions.closeElement('loadingModal'));
-            fireEvent('finishedSavingPDF');
-          },
-          error => {
-            dispatch(actions.closeElement('loadingModal'));
-            throw new Error(error.message);
-          },
-        );
-      }
-    })
-    .catch(() => {
+    if (externalURL) {
+      const downloadIframe =
+        document.getElementById('download-iframe') ||
+        document.createElement('iframe');
+      downloadIframe.width = 0;
+      downloadIframe.height = 0;
+      downloadIframe.id = 'download-iframe';
+      downloadIframe.src = null;
+      document.body.appendChild(downloadIframe);
+      downloadIframe.src = externalURL;
       dispatch(actions.closeElement('loadingModal'));
-    });
+      fireEvent('finishedSavingPDF');
+    } else {
+      return doc.getFileData(options).then(
+        data => {
+          const arr = new Uint8Array(data);
+          let file;
+
+          if (isIE) {
+            file = new Blob([arr], { type: 'application/pdf' });
+          } else {
+            file = new File([arr], downloadName, { type: 'application/pdf' });
+          }
+
+          saveAs(file, downloadName);
+          dispatch(actions.closeElement('loadingModal'));
+          fireEvent('finishedSavingPDF');
+        },
+        error => {
+          dispatch(actions.closeElement('loadingModal'));
+          throw new Error(error.message);
+        },
+      );
+    }
+  })
+  .catch(() => {
+    dispatch(actions.closeElement('loadingModal'));
+  });
 };

--- a/src/helpers/downloadPdf.js
+++ b/src/helpers/downloadPdf.js
@@ -67,8 +67,7 @@ export default (dispatch, options = {}) => {
         },
       );
     }
-  })
-  .catch(() => {
+  }).catch(() => {
     dispatch(actions.closeElement('loadingModal'));
   });
 };


### PR DESCRIPTION
When includeAnnotations was false the original annotations
still appeared. It appears we need to pass an empty xfdf
string to make sure that no annotations show up.
Also made it to so that exportAnnotations isn't called
in this case or an overriding xfdfString is passed