### PR TITLE
[Feature] Option for loading office file as pdf

### DIFF
--- a/src/helpers/loadDocument.js
+++ b/src/helpers/loadDocument.js
@@ -36,6 +36,7 @@ const getDefaultOptions = () => ({
   streaming: getHashParams('streaming', false),
   useDownloader: getHashParams('useDownloader', true),
   backendType: getHashParams('pdf', null),
+  loadAsPDF: getHashParams('loadAsPDF', null),
 });
 
 /**


### PR DESCRIPTION
This is the UI side for loading office documents as pdfs. After this, you can just add 
` loadAsPDF: true,` into the WebViewer constructor options and it'll work