### PR TITLE
Fix issue where line measurements would be visible after deleting

### DIFF
--- a/src/components/MeasurementOverlay/LineMeasurementInput.js
+++ b/src/components/MeasurementOverlay/LineMeasurementInput.js
@@ -52,7 +52,7 @@ function LineMeasurementInput(props) {
 
   const forceLineRedraw = useCallback(() => {
     const annotationManager = core.getAnnotationManager();
-    annotationManager.redrawAnnotation(annotation);
+    annotationManager.drawAnnotations(annotation.PageNumber);
     annotationManager.trigger('annotationChanged', [[annotation], 'modify', {}]);
   }, [annotation]);
 


### PR DESCRIPTION
This was because of the timing of how redrawAnnotation was called
after the annotation was deleted which made it incorrectly stick
around as the pending annotation. Using drawAnnotations will not
cause this problem.