### PR TITLE
[Bugfix] Thumbnail update rendering fix

### DIFF
--- a/src/components/Thumbnail/Thumbnail.js
+++ b/src/components/Thumbnail/Thumbnail.js
@@ -76,14 +76,13 @@ class Thumbnail extends React.PureComponent {
     const { index, pageLabels } = this.props;
 
     const currentPage = index + 1;
-    const currentPageStr = `${currentPage}`;
 
     const isPageAdded = added.indexOf(currentPage) > -1;
     const didPageChange = contentChanged.some(
-      changedPage => currentPageStr === changedPage,
+      changedPage => currentPage === changedPage,
     );
     const didPageMove = Object.keys(moved).some(
-      movedPage => currentPageStr === movedPage,
+      movedPage => currentPage === movedPage,
     );
     const isPageRemoved = removed.indexOf(currentPage) > -1;
     const newPageCount = pageLabels.length - removed.length;
@@ -95,6 +94,9 @@ class Thumbnail extends React.PureComponent {
 
     if (isPageAdded || didPageChange || didPageMove || isPageRemoved) {
       this.loadThumbnailAsync();
+      if (this.props.updateAnnotations) {
+        this.props.updateAnnotations(index);
+      }
     }
   }
 

--- a/src/components/Thumbnail/Thumbnail.js
+++ b/src/components/Thumbnail/Thumbnail.js
@@ -82,7 +82,7 @@ class Thumbnail extends React.PureComponent {
       changedPage => currentPage === changedPage,
     );
     const didPageMove = Object.keys(moved).some(
-      movedPage => currentPage === movedPage,
+      movedPage => currentPage === parseInt(movedPage),
     );
     const isPageRemoved = removed.indexOf(currentPage) > -1;
     const newPageCount = pageLabels.length - removed.length;

--- a/src/components/ThumbnailsPanel/ThumbnailsPanel.js
+++ b/src/components/ThumbnailsPanel/ThumbnailsPanel.js
@@ -386,7 +386,6 @@ class ThumbnailsPanel extends React.PureComponent {
         {
           new Array(numberOfColumns).fill().map((_, columnIndex) => {
             const thumbIndex = index * numberOfColumns + columnIndex;
-            const updateHandler = thumbs && thumbs[thumbIndex] ? thumbs[thumbIndex].updateAnnotationHandler : null;
             const showPlaceHolder = (isThumbnailMergingEnabled || isThumbnailReorderingEnabled) && draggingOverPageIndex === thumbIndex;
 
             return thumbIndex < this.props.totalPages ? (
@@ -405,7 +404,7 @@ class ThumbnailsPanel extends React.PureComponent {
                   onDragStart={this.onDragStart}
                   onDragOver={this.onDragOver}
                   onFinishLoading={this.removeFromPendingThumbs}
-                  updateAnnotations={updateHandler}
+                  updateAnnotations={this.updateAnnotations}
                 />
                 {showPlaceHolder && !isDraggingToPreviousPage && (
                   <hr className="thumbnailPlaceholder" />


### PR DESCRIPTION
Fixed some issues with how thumbnails are rendering. Issues fixed are

- Show current annotations for the initial load of the thumbnail panel
- Update thumbnails after applying redaction or pages operation (move, insert, delete, rotate)

![ThumbnailRendering2](https://user-images.githubusercontent.com/45575633/78283898-5e770000-74d3-11ea-89f8-81a3c5fd038a.gif)

