### PR TITLE
[CHANGE] can style grouped annotation

### DIFF
--- a/src/components/AnnotationPopup/AnnotationPopup.js
+++ b/src/components/AnnotationPopup/AnnotationPopup.js
@@ -226,7 +226,7 @@ const AnnotationPopup = () => {
           {canModify &&
             hasStyle &&
             !isAnnotationStylePopupDisabled &&
-            !multipleAnnotationsSelected &&
+            (!multipleAnnotationsSelected || canUngroup) &&
             firstAnnotation.ToolName !== 'CropPage' && (
             <ActionButton
               dataElement="annotationStyleEditButton"


### PR DESCRIPTION
We can style grouped annotations.
It doesn't quite match Adobe's, but it should be intuitive enough.

Assuming an annotation is grouped, if you click on it and style it, it will only style the annotation you clicked on.

This feature was requested by a customer.

If we go Adobe's way, it may take a bit more time with implementation