### PR TITLE
[CHANGE] fix(AnnotationContentOverlay): do not show the component when a modal is open

### DIFF
--- a/src/components/AnnotationContentOverlay/AnnotationContentOverlay.js
+++ b/src/components/AnnotationContentOverlay/AnnotationContentOverlay.js
@@ -22,26 +22,13 @@ const AnnotationContentOverlay = () => {
   });
 
   useEffect(() => {
-    const isMouseOnModal = e => {
-      let node = e.target;
-
-      while (node && node !== document.body) {
-        if (node.classList.contains('Modal')) {
-          return true;
-        }
-
-        node = node.parentNode;
-      }
-
-      return false;
-    };
-
     const onMouseHover = e => {
+      const viewElement = core.getViewerElement();
       let annotation = core
         .getAnnotationManager()
         .getAnnotationByMouseEvent(e);
 
-      if (annotation && !isMouseOnModal(e)) {
+      if (annotation && viewElement.contains(e.target)) {
         // if hovered annot is grouped, pick the "primary" annot to match Adobe's behavior
         const groupedAnnots = core.getAnnotationManager().getGroupAnnotations(annotation);
         const ungroupedAnnots = groupedAnnots.filter(annot => !annot.isGrouped());

--- a/src/components/AnnotationContentOverlay/AnnotationContentOverlay.js
+++ b/src/components/AnnotationContentOverlay/AnnotationContentOverlay.js
@@ -22,27 +22,43 @@ const AnnotationContentOverlay = () => {
   });
 
   useEffect(() => {
+    const isMouseOnModal = e => {
+      let node = e.target;
+
+      while (node && node !== document.body) {
+        if (node.classList.contains('Modal')) {
+          return true;
+        }
+
+        node = node.parentNode;
+      }
+
+      return false;
+    };
+
     const onMouseHover = e => {
       let annotation = core
         .getAnnotationManager()
         .getAnnotationByMouseEvent(e);
 
-      if (annotation) {
-        // if hovered annot is grouped, pick the "primary" annot
-        // do this as this is what Adobe does
+      if (annotation && !isMouseOnModal(e)) {
+        // if hovered annot is grouped, pick the "primary" annot to match Adobe's behavior
         const groupedAnnots = core.getAnnotationManager().getGroupAnnotations(annotation);
         const ungroupedAnnots = groupedAnnots.filter(annot => !annot.isGrouped());
         annotation = ungroupedAnnots.length > 0 ? ungroupedAnnots[0] : annotation;
-      }
 
-      if (!(annotation instanceof Annotations.FreeTextAnnotation)) {
-        setAnnotation(annotation);
-        setOverlayPosition({
-          left: e.clientX + 20,
-          top: e.clientY + 20,
-        });
+        if (!(annotation instanceof Annotations.FreeTextAnnotation)) {
+          setAnnotation(annotation);
+          setOverlayPosition({
+            left: e.clientX + 20,
+            top: e.clientY + 20,
+          });
+        }
+      } else {
+        setAnnotation(null);
       }
     };
+
     core.addEventListener('mouseMove', onMouseHover);
     return () => {
       core.removeEventListener('mouseMove', onMouseHover);


### PR DESCRIPTION
Checks if the mouse in moving on a modal component to decide if we are hovering on an annotation. Fixes #570.