### PR TITLE
[Bugfix] Fix scrolling with track pad changing pages

### DIFF
--- a/src/components/DocumentContainer/DocumentContainer.js
+++ b/src/components/DocumentContainer/DocumentContainer.js
@@ -128,9 +128,9 @@ class DocumentContainer extends React.PureComponent {
     const reachedTop = scrollTop === 0;
     const reachedBottom = Math.abs(scrollTop + clientHeight - scrollHeight) <= 1;
 
-    // depending on the track pad used (see this on MacBooks), deltaY can be randomly between 1 and -1 which cause page change
+    // depending on the track pad used (see this on MacBooks), deltaY can be between -1 and 1 when doing horizontal scrolling which cause page to change
     const scrollingUp = e.deltaY < 0 && Math.abs(e.deltaY) > Math.abs(e.deltaX);
-    const scrollingDown = e.deltaY> 0 && Math.abs(e.deltaY) > Math.abs(e.deltaX);
+    const scrollingDown = e.deltaY > 0 && Math.abs(e.deltaY) > Math.abs(e.deltaX);
 
     if (scrollingUp && reachedTop && currentPage > 1) {
       this.pageUp();

--- a/src/components/DocumentContainer/DocumentContainer.js
+++ b/src/components/DocumentContainer/DocumentContainer.js
@@ -128,9 +128,13 @@ class DocumentContainer extends React.PureComponent {
     const reachedTop = scrollTop === 0;
     const reachedBottom = Math.abs(scrollTop + clientHeight - scrollHeight) <= 1;
 
-    if (e.deltaY < 0 && reachedTop && currentPage > 1) {
+    // depending on the track pad used (see this on MacBooks), deltaY can go between 1 and -1 which cause it to go to another page
+    const scrollingUp = e.deltaY < 0 && Math.abs(e.deltaY) > Math.abs(e.deltaX);
+    const scrollingDown = e.deltaY> 0 && Math.abs(e.deltaY) > Math.abs(e.deltaX);
+
+    if (scrollingUp && reachedTop && currentPage > 1) {
       this.pageUp();
-    } else if (e.deltaY > 0 && reachedBottom && currentPage < totalPages) {
+    } else if (scrollingDown && reachedBottom && currentPage < totalPages) {
       this.pageDown();
     }
   }

--- a/src/components/DocumentContainer/DocumentContainer.js
+++ b/src/components/DocumentContainer/DocumentContainer.js
@@ -128,7 +128,7 @@ class DocumentContainer extends React.PureComponent {
     const reachedTop = scrollTop === 0;
     const reachedBottom = Math.abs(scrollTop + clientHeight - scrollHeight) <= 1;
 
-    // depending on the track pad used (see this on MacBooks), deltaY can go between 1 and -1 which cause it to go to another page
+    // depending on the track pad used (see this on MacBooks), deltaY can be randomly between 1 and -1 which cause page change
     const scrollingUp = e.deltaY < 0 && Math.abs(e.deltaY) > Math.abs(e.deltaX);
     const scrollingDown = e.deltaY> 0 && Math.abs(e.deltaY) > Math.abs(e.deltaX);
 


### PR DESCRIPTION
If you change WebViewer to display a single page only, and scroll left to right slowly on a trackpad, it'll randomly jump to page two. You can use the following document to test

[pageRatio.xlsx](https://github.com/PDFTron/webviewer-ui/files/4512149/pageRatio.xlsx)

I tested this on an old macBook and see that the "e.deltaY" will be between -1 and 1  when doing horizontal scrolling which cause the page to change. 
