### PR TITLE
feat(api): add setActivePalette and setColorPalette APIs

### DIFF
--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -83,6 +83,7 @@ import setActiveHeaderGroup from './setActiveHeaderGroup';
 import setActiveLeftPanel from './setActiveLeftPanel';
 import setAdminUser from './setAdminUser';
 import setAnnotationUser from './setAnnotationUser';
+import setActivePalette from './setActivePalette';
 import setColorPalette from './setColorPalette';
 import setCurrentPageNumber from './setCurrentPageNumber';
 import setCustomNoteFilter from './setCustomNoteFilter';
@@ -243,6 +244,8 @@ export default store => {
     setNotesPanelSort: setNotesPanelSort(store),
     setShowSideWindow: setShowSideWindow(store),
     setSideWindowVisibility: setSideWindowVisibility(store),
+    setActivePalette: setActivePalette(store),
+    setColorPalette: setColorPalette(store),
     disableTool: disableTool(store),
     enableAllElements: enableAllElements(store),
     goToFirstPage,
@@ -268,7 +271,6 @@ export default store => {
     loadedFromServer: false,
     serverFailed: false,
     i18n: i18next,
-    setColorPalette: setColorPalette(store),
     showWarningMessage: showWarningMessage(store),
     updateOutlines: updateOutlines(store),
     getBBAnnotManager,

--- a/src/apis/setActivePalette.js
+++ b/src/apis/setActivePalette.js
@@ -1,0 +1,27 @@
+import actions from 'actions';
+import { getDataWithKey, mapToolNameToKey } from 'constants/map';
+import mapPaletteToAnnotationColorProperty from 'constants/mapPaletteToAnnotationColorProperty';
+import mapAnnotationColorPropertyToPalette from 'constants/mapAnnotationColorPropertyToPalette';
+
+/**
+ * Sets the active color palette of a tool and its associated annotation
+ * @method WebViewerInstance#setActivePalette
+ * @param {string} toolName Name of the tool, either from <a href='https://www.pdftron.com/documentation/web/guides/annotations-and-tools/#list-of-tool-names' target='_blank'>tool names list</a> or the name you registered your custom tool with.
+ * @param {'text'|'border'|'fill'} colorPalette The palette to be activated. One of 'text', 'border' and 'fill'.
+ * @example
+WebViewer(...)
+  .then(function(instance) {
+    instance.setActivePalette('AnnotationCreateFreeText', 'fill')
+  });
+ */
+
+export default store => (toolName, colorPalette) => {
+  const availablePalettes = getDataWithKey(mapToolNameToKey(toolName)).availablePalettes;
+  const property = mapPaletteToAnnotationColorProperty[colorPalette];
+
+  if (availablePalettes.includes(property)) {
+    store.dispatch(actions.setActivePalette(mapToolNameToKey(toolName), property));
+  } else {
+    console.warn(`${toolName} does not have ${colorPalette} color, available colors are: ${availablePalettes.map(palette => mapAnnotationColorPropertyToPalette[palette]).join(', ')} `);
+  }
+};

--- a/src/apis/setColorPalette.js
+++ b/src/apis/setColorPalette.js
@@ -1,14 +1,61 @@
+import { mapToolNameToKey } from 'constants/map';
 import actions from 'actions';
-import { getDataWithKey, mapToolNameToKey } from 'constants/map';
-import mapPaletteToAnnotationColorProperty from 'constants/mapPaletteToAnnotationColorProperty';
-import mapAnnotationColorPropertyToPalette from 'constants/mapAnnotationColorPropertyToPalette';
+import selectors from 'selectors';
 
-export default store => (toolName, colorPalette) => {
-  const availablePalettes = getDataWithKey(mapToolNameToKey(toolName)).availablePalettes;
-  const property = mapPaletteToAnnotationColorProperty[colorPalette];
-  if (availablePalettes.includes(property)) {
-    store.dispatch(actions.setColorPalette(mapToolNameToKey(toolName), property));
-  } else {
-    console.warn(`${toolName} does not have ${colorPalette} color, available colors are: ${availablePalettes.map(palette => mapAnnotationColorPropertyToPalette[palette]).join(', ')} `);
+/**
+ * @typedef WebViewerInstance.PaletteOption
+ * @property {string[]} toolNames Tools that will have the same colors in the palette.
+ * @property {string[]} colors An array of hex colors. Use 'transparency' for a transparent color.
+ */
+
+/**
+ * Sets the colors in the palette globally or for specific tools and their associated annotations
+ * @method WebViewerInstance#setColorPalette
+ * @param {string[]|WebViewerInstance.PaletteOption} An array of hex colors that will override the default colors for every tool.
+ * An object can be passed to specify colors for particular tools.
+ * @example
+WebViewer(...)
+  .then(function(instance) {
+    // this sets the palette globally. All the tools will use these colors.
+    instance.setColorPalette(['#FFFFFF', '#DDDDDD', 'transparency']);
+
+    // use a different set of colors for the freetext and rectangle tool.
+    instance.setColorPalette({
+      toolNames: ['AnnotationCreateFreeText', 'AnnotationCreateRectangle'],
+      colors: ['#333333'],
+    })
+  });
+ */
+
+export default store => overrides => {
+  const currentOverride = {
+    ...(selectors.getCustomElementOverrides(store.getState(), 'colorPalette') || {}),
+  };
+
+  if (Array.isArray(overrides)) {
+    if (overrides.every(isValidColor)) {
+      currentOverride.global = overrides;
+    } else {
+      return console.warn(
+        `An array is passed to setColorPalette, but some colors are invalid. A color must be 'transparency' or a hex color string. For example #F0F0F0`
+      );
+    }
+  } else if (typeof overrides === 'object') {
+    if (overrides.toolNames && overrides.colors) {
+      overrides.toolNames.forEach(toolName => {
+        const key = mapToolNameToKey(toolName);
+        currentOverride[key] = overrides.colors;
+      });
+    } else {
+      return console.warn(
+        `An object is passed to setColorPalette, but it doesn't have a toolNames or colors property.`
+      );
+    }
   }
+
+  store.dispatch(actions.setCustomElementOverrides('colorPalette', currentOverride));
 };
+
+// examples of valid colors are: '#f0f0f0', '#FFFFFF'
+const isValidColor = color =>
+  color === 'transparency' || (color.startsWith('#') && color.split('#')[1].length === 6);

--- a/src/apis/updateElement.js
+++ b/src/apis/updateElement.js
@@ -1,10 +1,11 @@
 import actions from 'actions';
+import setColorPalette from './setColorPalette';
 
 /**
  * Update an element in the viewer.
  * @method WebViewerInstance#updateElement
- * @param {string} dataElement the data element of the element that will be updated. Valid values are 'colorPalette', and HTML elements that have 'Button' in the class name.
- * @param {*} props An object or an array that is used to override an existing item's properties.
+ * @param {string} dataElement the data element of the element that will be updated. Only the data element of HTML elements that have 'Button' in the class name will work.
+ * @param {*} props An object that is used to override an existing item's properties.
  * @example
 WebViewer(...)
   .then(function(instance) {
@@ -12,41 +13,19 @@ WebViewer(...)
       img: 'path/to/image',
       title: 'new_tooltip',
     })
-
-    instance.updateElement('colorPalette', ['#FFFFFF', 'transparency', '#000000'])
   });
  */
 export default store => (dataElement, overrides) => {
   switch (dataElement) {
+    // for backwards compatibility
     case 'colorPalette':
-      overrides = validateColorPaletteOverrides(overrides);
+      setColorPalette(overrides);
       break;
     default:
-      overrides = validateButtonOverrides(overrides);
+      if (validateButtonOverrides(overrides)) {
+        store.dispatch(actions.setCustomElementOverrides(dataElement, overrides));
+      }
   }
-
-  if (overrides) {
-    store.dispatch(actions.setCustomElementOverrides(dataElement, overrides));
-  }
-};
-
-const validateColorPaletteOverrides = overrides => {
-  if (!Array.isArray(overrides)) {
-    return console.warn(
-      'The second argument needs to be an array of strings to update the color palette',
-    );
-  }
-
-  // examples of valid colors are: '#f0f0f0', '#FFFFFF'
-  const isValidColor = color =>
-    color === 'transparency' ||
-    (color.startsWith('#') && color.split('#')[1].length === 6);
-
-  if (!overrides.every(isValidColor)) {
-    return console.warn('The color must be \'transparency\' or a hex color string. For example #F0F0F0');
-  }
-
-  return overrides;
 };
 
 const validateButtonOverrides = overrides => {

--- a/src/components/ColorPalette/ColorPalette.js
+++ b/src/components/ColorPalette/ColorPalette.js
@@ -16,7 +16,8 @@ class ColorPalette extends React.PureComponent {
     property: PropTypes.string.isRequired,
     color: PropTypes.object.isRequired,
     onStyleChange: PropTypes.func.isRequired,
-    overridePalette: PropTypes.array,
+    colorMapKey: PropTypes.string.isRequired,
+    overridePalette: PropTypes.object,
   };
 
   defaultPalette = [
@@ -53,33 +54,21 @@ class ColorPalette extends React.PureComponent {
   setColor = e => {
     const { property, onStyleChange } = this.props;
     const bg = e.target.style.backgroundColor; // rgb(r, g, b);
-    const rgba = bg
-      ? bg.slice(bg.indexOf('(') + 1, -1).split(',')
-      : [0, 0, 0, 0];
-    const color = new window.Annotations.Color(
-      rgba[0],
-      rgba[1],
-      rgba[2],
-      rgba[3],
-    );
+    const rgba = bg ? bg.slice(bg.indexOf('(') + 1, -1).split(',') : [0, 0, 0, 0];
+    const color = new window.Annotations.Color(rgba[0], rgba[1], rgba[2], rgba[3]);
     onStyleChange(property, color);
   };
 
   renderTransparencyCell = bg => {
     const { property } = this.props;
-    const shouldRenderDummyCell =
-      property === 'TextColor' || property === 'StrokeColor';
+    const shouldRenderDummyCell = property === 'TextColor' || property === 'StrokeColor';
 
     if (shouldRenderDummyCell) {
       return <div className="dummy-cell" />;
     }
 
     const diagonalLine = (
-      <svg
-        width="100%"
-        height="100%"
-        style={{ position: 'absolute', top: '0px', left: '0px' }}
-      >
+      <svg width="100%" height="100%" style={{ position: 'absolute', top: '0px', left: '0px' }}>
         <line
           x1="0%"
           y1="100%"
@@ -132,24 +121,19 @@ class ColorPalette extends React.PureComponent {
     }
 
     return isColorPicked ? (
-      <Icon
-        className={`check-mark ${getBrightness(color)}`}
-        glyph="ic_check_black_24px"
-      />
+      <Icon className={`check-mark ${getBrightness(color)}`} glyph="ic_check_black_24px" />
     ) : null;
   };
 
   render() {
-    const { overridePalette } = this.props;
-    const palette = overridePalette || this.defaultPalette;
+    const { overridePalette, colorMapKey } = this.props;
+    const palette = overridePalette?.[colorMapKey] || overridePalette?.global || this.defaultPalette;
 
     return (
       <div className="ColorPalette" data-element={dataElement}>
-        {palette.map((bg, i) => (
-          <React.Fragment key={i}>
-            {bg === 'transparency'
-              ? this.renderTransparencyCell(bg)
-              : this.renderColorCell(bg)}
+        {palette.map(bg => (
+          <React.Fragment key={bg}>
+            {bg === 'transparency' ? this.renderTransparencyCell(bg) : this.renderColorCell(bg)}
           </React.Fragment>
         ))}
       </div>

--- a/src/components/ColorPaletteHeader/ColorPaletteHeader.js
+++ b/src/components/ColorPaletteHeader/ColorPaletteHeader.js
@@ -17,17 +17,17 @@ class ColorPaletteHeader extends React.PureComponent {
     style: PropTypes.object.isRequired,
     colorPalette: PropTypes.oneOf(['TextColor', 'StrokeColor', 'FillColor']),
     colorMapKey: PropTypes.string.isRequired,
-    setColorPalette: PropTypes.func.isRequired,
+    setActivePalette: PropTypes.func.isRequired,
     t: PropTypes.func.isRequired,
     isTextColorPaletteDisabled: PropTypes.bool,
     isFillColorPaletteDisabled: PropTypes.bool,
     isBorderColorPaletteDisabled: PropTypes.bool,
   }
 
-  setColorPalette = newPalette => {
-    const { setColorPalette, colorMapKey } = this.props;
+  setActivePalette = newPalette => {
+    const { setActivePalette, colorMapKey } = this.props;
 
-    setColorPalette(colorMapKey, newPalette);
+    setActivePalette(colorMapKey, newPalette);
   }
 
   renderTextColorIcon = () => {
@@ -38,7 +38,7 @@ class ColorPaletteHeader extends React.PureComponent {
         <div
           className={colorPalette === 'TextColor' ? 'text selected' : 'text'}
           style={{ color: TextColor.toHexString() }}
-          onClick={() => this.setColorPalette('TextColor')}
+          onClick={() => this.setActivePalette('TextColor')}
         >
           Aa
         </div>
@@ -70,7 +70,7 @@ class ColorPaletteHeader extends React.PureComponent {
       <Tooltip content="option.annotationColor.StrokeColor">
         <div
           className={colorPalette === 'StrokeColor' ? 'border selected' : 'border'}
-          onClick={() => this.setColorPalette('StrokeColor')}
+          onClick={() => this.setActivePalette('StrokeColor')}
         >
           <div
             className={`border-icon ${getBrightness(StrokeColor)}}`}
@@ -91,7 +91,7 @@ class ColorPaletteHeader extends React.PureComponent {
       <Tooltip content="option.annotationColor.FillColor">
         <div
           className={colorPalette === 'FillColor' ? 'fill selected' : 'fill'}
-          onClick={() => this.setColorPalette('FillColor')}
+          onClick={() => this.setActivePalette('FillColor')}
         >
           <div
             className={`fill-icon ${getBrightness(FillColor)} ${isTransparency ? 'transparency' : ''}`}
@@ -151,7 +151,7 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = {
-  setColorPalette: actions.setColorPalette,
+  setActivePalette: actions.setActivePalette,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(withTranslation(null, { wait: false })(ColorPaletteHeader));

--- a/src/components/StylePopup/StylePopup.js
+++ b/src/components/StylePopup/StylePopup.js
@@ -36,13 +36,14 @@ class StylePopup extends React.PureComponent {
   };
 
   renderColorPalette = () => {
-    const { style, onStyleChange, currentPalette } = this.props;
+    const { style, onStyleChange, currentPalette, colorMapKey } = this.props;
 
     return (
       <ColorPalette
         color={style[currentPalette]}
         property={currentPalette}
         onStyleChange={onStyleChange}
+        colorMapKey={colorMapKey}
       />
     );
   };

--- a/src/redux/actions/internalActions.js
+++ b/src/redux/actions/internalActions.js
@@ -200,6 +200,10 @@ export const setColorPalette = (colorMapKey, colorPalette) => ({
   type: 'SET_COLOR_PALETTE',
   payload: { colorMapKey, colorPalette },
 });
+export const setActivePalette = (colorMapKey, colorPalette) => ({
+  type: 'SET_ACTIVE_PALETTE',
+  payload: { colorMapKey, colorPalette },
+});
 export const setIconColor = (colorMapKey, color) => ({
   type: 'SET_ICON_COLOR',
   payload: { colorMapKey, color },
@@ -355,4 +359,4 @@ export const setIsProgrammaticSearchFull = isProgrammaticSearchFull => ({
 export const setNoteTransformFunction = noteTransformFunction => ({
   type: 'SET_NOTE_TRANSFORM_FUNCTION',
   payload: { noteTransformFunction },
-})
+});

--- a/src/redux/reducers/viewerReducer.js
+++ b/src/redux/reducers/viewerReducer.js
@@ -171,7 +171,7 @@ export default initialState => (state = initialState, action) => {
       return { ...state, pageLabels: [...payload.pageLabels] };
     case 'SET_SELECTED_THUMBNAIL_PAGE_INDEXES':
       return { ...state, selectedThumbnailPageIndexes: payload.selectedThumbnailPageIndexes };
-    case 'SET_COLOR_PALETTE': {
+    case 'SET_ACTIVE_PALETTE': {
       const { colorMapKey, colorPalette } = payload;
       return {
         ...state,
@@ -229,7 +229,7 @@ export default initialState => (state = initialState, action) => {
     case 'SET_CUSTOM_ELEMENT_OVERRIDES':
       return { ...state, customElementOverrides: { ...state.customElementOverrides, [payload.dataElement]: payload.overrides } };
     case 'SET_NOTE_TRANSFORM_FUNCTION':
-      return { ...state, noteTransformFunction: payload.noteTransformFunction }
+      return { ...state, noteTransformFunction: payload.noteTransformFunction };
     default:
       return state;
   }


### PR DESCRIPTION
`setActivePalette` allows users to programmatically set the active color palette for a tool and its annotations.
`setColorPalette` allows users to set different colors for all of the tools or specific tools.

```javascript
instance.setColorPalette(['#FFFFFF', '#001133', '#DDDDDD', '#12345D']);
instance.setColorPalette({
  toolNames: ['AnnotationCreateRectangle', 'AnnotationCreatePolygon'],
  colors: ['#FFFFFF', 'transparency', '#000000'],
});
instance.setColorPalette({
  toolNames: ['AnnotationCreateFreeText'],
  colors: ['#000000'],
});
```

  