### PR TITLE
[CHANGE] able to show thumbnails like a grid on drag of thumbnail panel

### DIFF
--- a/src/components/ThumbnailsPanel/ThumbnailsPanel.js
+++ b/src/components/ThumbnailsPanel/ThumbnailsPanel.js
@@ -213,22 +213,6 @@ class ThumbnailsPanel extends React.PureComponent {
   }
 
   getNumberOfColumns = () => {
-    // const desktopBreakPoint = 640;
-    // const { innerWidth } = window;
-    // let numberOfColumns;
-
-    // if (innerWidth >= desktopBreakPoint) {
-    //   numberOfColumns = 1;
-    // // TODO: use forwardRef to get the width of the thumbnail div instead of using the magic 20px
-    // } else if (innerWidth >= 3 * (THUMBNAIL_SIZE + 20)) {
-    //   numberOfColumns = 3;
-    // } else if (innerWidth >= 2 * (THUMBNAIL_SIZE + 20)) {
-    //   numberOfColumns = 2;
-    // } else {
-    //   numberOfColumns = 1;
-    // }
-
-    // return numberOfColumns;
     const numberOfColumns = Math.min(3, Math.max(1, Math.floor(this.state && this.state.width ? this.state.width / 160 : 0)));
     return numberOfColumns;
   }

--- a/src/components/ThumbnailsPanel/ThumbnailsPanel.js
+++ b/src/components/ThumbnailsPanel/ThumbnailsPanel.js
@@ -35,7 +35,6 @@ class ThumbnailsPanel extends React.PureComponent {
     this.listRef = React.createRef();
     this.afterMovePageNumber = null;
     this.state = {
-      numberOfColumns: 1,
       isDocumentControlHidden: true,
       canLoad: true,
       height: 0,
@@ -53,7 +52,6 @@ class ThumbnailsPanel extends React.PureComponent {
     core.addEventListener('pageNumberUpdated', this.onPageNumberUpdated);
     core.addEventListener('pageComplete', this.onPageComplete);
     core.addEventListener('annotationHidden', this.onAnnotationChanged);
-    window.addEventListener('resize', this.onWindowResize);
   }
 
   componentWillUnmount() {
@@ -63,7 +61,6 @@ class ThumbnailsPanel extends React.PureComponent {
     core.removeEventListener('pageNumberUpdated', this.onPageNumberUpdated);
     core.removeEventListener('pageComplete', this.onPageComplete);
     core.removeEventListener('annotationHidden', this.onAnnotationChanged);
-    window.removeEventListener('resize', this.onWindowResize);
   }
 
   onBeginRendering = () => {
@@ -124,7 +121,7 @@ class ThumbnailsPanel extends React.PureComponent {
     e.preventDefault();
     e.stopPropagation();
 
-    const { numberOfColumns } = this.state;
+    const numberOfColumns = this.getNumberOfColumns(this.state.width);
     const { isThumbnailReorderingEnabled, isThumbnailMergingEnabled } = this.props;
 
     if (!isThumbnailReorderingEnabled && !isThumbnailMergingEnabled) {
@@ -204,12 +201,6 @@ class ThumbnailsPanel extends React.PureComponent {
 
   onPageNumberUpdated = pageNumber => {
     this.listRef.current?.scrollToRow(pageNumber - 1);
-  }
-
-  onWindowResize = () => {
-    this.setState({
-      numberOfColumns: this.getNumberOfColumns(this.state.width),
-    });
   }
 
   getNumberOfColumns = width => {
@@ -341,11 +332,12 @@ class ThumbnailsPanel extends React.PureComponent {
 
   renderThumbnails = ({ index, key, style }) => {
     const {
-      numberOfColumns,
       canLoad,
       draggingOverPageIndex,
       isDraggingToPreviousPage,
+      width,
     } = this.state;
+    const numberOfColumns = this.getNumberOfColumns(width);
     const { isThumbnailReorderingEnabled, isThumbnailMergingEnabled, selectedPageIndexes } = this.props;
     const { thumbs } = this;
     const className = classNames({
@@ -401,13 +393,13 @@ class ThumbnailsPanel extends React.PureComponent {
     this.setState({
       height: bounds.height,
       width: bounds.width,
-      numberOfColumns: this.getNumberOfColumns(bounds.width),
     });
   }
 
   render() {
     const { isDisabled, totalPages, display, isThumbnailControlDisabled, selectedPageIndexes } = this.props;
-    const { numberOfColumns, height, width, documentControlHeight, isDocumentControlHidden } = this.state;
+    const { height, width, documentControlHeight, isDocumentControlHidden } = this.state;
+    const numberOfColumns = this.getNumberOfColumns(this.state.width);
     const thumbnailHeight = isThumbnailControlDisabled ? 200 : 230;
 
     const shouldShowControls = !isDocumentControlHidden || selectedPageIndexes.length > 0;

--- a/src/components/ThumbnailsPanel/ThumbnailsPanel.js
+++ b/src/components/ThumbnailsPanel/ThumbnailsPanel.js
@@ -213,21 +213,23 @@ class ThumbnailsPanel extends React.PureComponent {
   }
 
   getNumberOfColumns = () => {
-    const desktopBreakPoint = 640;
-    const { innerWidth } = window;
-    let numberOfColumns;
+    // const desktopBreakPoint = 640;
+    // const { innerWidth } = window;
+    // let numberOfColumns;
 
-    if (innerWidth >= desktopBreakPoint) {
-      numberOfColumns = 1;
-    // TODO: use forwardRef to get the width of the thumbnail div instead of using the magic 20px
-    } else if (innerWidth >= 3 * (THUMBNAIL_SIZE + 20)) {
-      numberOfColumns = 3;
-    } else if (innerWidth >= 2 * (THUMBNAIL_SIZE + 20)) {
-      numberOfColumns = 2;
-    } else {
-      numberOfColumns = 1;
-    }
+    // if (innerWidth >= desktopBreakPoint) {
+    //   numberOfColumns = 1;
+    // // TODO: use forwardRef to get the width of the thumbnail div instead of using the magic 20px
+    // } else if (innerWidth >= 3 * (THUMBNAIL_SIZE + 20)) {
+    //   numberOfColumns = 3;
+    // } else if (innerWidth >= 2 * (THUMBNAIL_SIZE + 20)) {
+    //   numberOfColumns = 2;
+    // } else {
+    //   numberOfColumns = 1;
+    // }
 
+    // return numberOfColumns;
+    const numberOfColumns = Math.min(3, Math.max(1, Math.floor(this.state && this.state.width ? this.state.width / 160 : 0)));
     return numberOfColumns;
   }
 
@@ -432,6 +434,10 @@ class ThumbnailsPanel extends React.PureComponent {
             this.setState({
               height: bounds.height,
               width: bounds.width,
+            }, () => {
+              this.setState({
+                numberOfColumns: this.getNumberOfColumns()
+              });
             });
           }}
         >

--- a/src/components/ThumbnailsPanel/ThumbnailsPanel.js
+++ b/src/components/ThumbnailsPanel/ThumbnailsPanel.js
@@ -35,7 +35,7 @@ class ThumbnailsPanel extends React.PureComponent {
     this.listRef = React.createRef();
     this.afterMovePageNumber = null;
     this.state = {
-      numberOfColumns: this.getNumberOfColumns(),
+      numberOfColumns: 1,
       isDocumentControlHidden: true,
       canLoad: true,
       height: 0,
@@ -208,12 +208,12 @@ class ThumbnailsPanel extends React.PureComponent {
 
   onWindowResize = () => {
     this.setState({
-      numberOfColumns: this.getNumberOfColumns(),
+      numberOfColumns: this.getNumberOfColumns(this.state.width),
     });
   }
 
-  getNumberOfColumns = () => {
-    const numberOfColumns = Math.min(3, Math.max(1, Math.floor(this.state && this.state.width ? this.state.width / 160 : 0)));
+  getNumberOfColumns = width => {
+    const numberOfColumns = Math.min(3, Math.max(1, Math.floor(width / 160)));
     return numberOfColumns;
   }
 
@@ -397,6 +397,14 @@ class ThumbnailsPanel extends React.PureComponent {
     });
   }
 
+  onPanelResize = ({ bounds }) => {
+    this.setState({
+      height: bounds.height,
+      width: bounds.width,
+      numberOfColumns: this.getNumberOfColumns(bounds.width),
+    });
+  }
+
   render() {
     const { isDisabled, totalPages, display, isThumbnailControlDisabled, selectedPageIndexes } = this.props;
     const { numberOfColumns, height, width, documentControlHeight, isDocumentControlHidden } = this.state;
@@ -414,16 +422,7 @@ class ThumbnailsPanel extends React.PureComponent {
       >
         <Measure
           bounds
-          onResize={({ bounds }) => {
-            this.setState({
-              height: bounds.height,
-              width: bounds.width,
-            }, () => {
-              this.setState({
-                numberOfColumns: this.getNumberOfColumns()
-              });
-            });
-          }}
+          onResize={this.onPanelResize}
         >
           {({ measureRef }) => (
             <div ref={measureRef} className="virtualized-thumbnails-container"


### PR DESCRIPTION
When dragging the thumbnail panel, the thumbnails don't seem to be rendered like a grid when its dragged to its max width. it still stays as 1 column. Only when you resize the browser, it will happen.

Made change so that it can have 1-3 depending on the thumbnail width without resizing the browser.

Adobe seems to have this kind of feature.