### PR TITLE
[Bugfix] Stop signature from entering into an error state 

### DIFF
--- a/src/helpers/hotkeysManager.js
+++ b/src/helpers/hotkeysManager.js
@@ -467,7 +467,7 @@ WebViewer(...)
       const openElements = selectors.getOpenElements(getState());
       const currentToolName = core.getToolMode().name;
     
-       // disable changing tool when the signature overlay is opened.
+      // disable changing tool when the signature overlay is opened.
       const isSignatureModalOpen = currentToolName === window.Tools.ToolNames.SIGNATURE && openElements['signatureModal'];
 
       if (isFocusingElement() || isSignatureModalOpen) {

--- a/src/helpers/hotkeysManager.js
+++ b/src/helpers/hotkeysManager.js
@@ -470,7 +470,7 @@ WebViewer(...)
        // disable changing tool when the signature overlay is opened.
       const isSignatureModalOpen = currentToolName === window.Tools.ToolNames.SIGNATURE && openElements['signatureModal'];
 
-      if (isFocusingElement() && isSignatureModalOpen) {
+      if (isFocusingElement() || isSignatureModalOpen) {
         return;
       }
 

--- a/src/helpers/hotkeysManager.js
+++ b/src/helpers/hotkeysManager.js
@@ -128,6 +128,7 @@ const HotkeysManager = {
   initialize(store) {
     // still allow hotkeys when focusing a textarea or an input
     hotkeys.filter = () => true;
+    this.store = store;
     this.keyHandlerMap = this.createKeyHandlerMap(store);
     this.prevToolName = null;
     Object.keys(this.keyHandlerMap).forEach(key => {
@@ -460,7 +461,17 @@ WebViewer(...)
    * @ignore
    */
   createToolHotkeyHandler(handler) {
+    const { getState } = this.store;
+
     return (...args) => {
+      const openElements = selectors.getOpenElements(getState());
+      const currentToolName = core.getToolMode().name;
+    
+      if (currentToolName=== window.Tools.ToolNames.SIGNATURE && openElements['signatureModal']) {
+        // disable changing tool when the signature overlay is opened
+        return;
+      }
+  
       if (!isFocusingElement()) {
         handler(...args);
       }

--- a/src/helpers/hotkeysManager.js
+++ b/src/helpers/hotkeysManager.js
@@ -467,14 +467,14 @@ WebViewer(...)
       const openElements = selectors.getOpenElements(getState());
       const currentToolName = core.getToolMode().name;
     
-      if (currentToolName=== window.Tools.ToolNames.SIGNATURE && openElements['signatureModal']) {
-        // disable changing tool when the signature overlay is opened
+       // disable changing tool when the signature overlay is opened.
+      const isSignatureModalOpen = currentToolName === window.Tools.ToolNames.SIGNATURE && openElements['signatureModal'];
+
+      if (isFocusingElement() && isSignatureModalOpen) {
         return;
       }
-  
-      if (!isFocusingElement()) {
-        handler(...args);
-      }
+
+      handler(...args);
     };
   },
   getHotkeyByToolName(toolName) {

--- a/src/helpers/setToolModeAndGroup.js
+++ b/src/helpers/setToolModeAndGroup.js
@@ -6,10 +6,10 @@ import selectors from 'selectors';
 export default (store, toolName) => {
   const { dispatch, getState } = store;
 
-  const openElement = selectors.getOpenElements(getState());
+  const openElements = selectors.getOpenElements(getState());
   const currentTool = core.getToolMode().name;
 
-  if (currentTool === window.Tools.ToolNames.SIGNATURE && openElement['signatureModal']) {
+  if (currentTool === window.Tools.ToolNames.SIGNATURE && openElements['signatureModal']) {
     // disable changing tool when the signature overlay is opened
     return;
   }
@@ -22,7 +22,7 @@ export default (store, toolName) => {
   } else {
     dispatch(actions.closeElement('toolsOverlay'));
   }
-  
+
   const hasToolBeenSelected = currentTool === toolName;
   if (hasToolBeenSelected && toolStylesExist(toolName)) {
     dispatch(actions.toggleElement('toolStylePopup'));

--- a/src/helpers/setToolModeAndGroup.js
+++ b/src/helpers/setToolModeAndGroup.js
@@ -22,7 +22,6 @@ export default (store, toolName) => {
     dispatch(actions.closeElement('toolsOverlay'));
   }
   const hasToolBeenSelected = core.getToolMode().name === toolName;
-
   if (hasToolBeenSelected && toolStylesExist(toolName)) {
     dispatch(actions.toggleElement('toolStylePopup'));
     return;

--- a/src/helpers/setToolModeAndGroup.js
+++ b/src/helpers/setToolModeAndGroup.js
@@ -10,6 +10,7 @@ export default (store, toolName) => {
   const currentTool = core.getToolMode().name;
 
   if (currentTool === window.Tools.ToolNames.SIGNATURE && openElement['signatureModal']) {
+    // disable changing tool when the signature overlay is opened
     return;
   }
 
@@ -21,7 +22,7 @@ export default (store, toolName) => {
   } else {
     dispatch(actions.closeElement('toolsOverlay'));
   }
-  const hasToolBeenSelected = core.getToolMode().name === toolName;
+  const hasToolBeenSelected = currentTool === toolName;
   if (hasToolBeenSelected && toolStylesExist(toolName)) {
     dispatch(actions.toggleElement('toolStylePopup'));
     return;

--- a/src/helpers/setToolModeAndGroup.js
+++ b/src/helpers/setToolModeAndGroup.js
@@ -5,6 +5,14 @@ import selectors from 'selectors';
 
 export default (store, toolName) => {
   const { dispatch, getState } = store;
+
+  const openElement = selectors.getOpenElements(getState());
+  const currentTool = core.getToolMode().name;
+
+  if (currentTool === window.Tools.ToolNames.SIGNATURE && openElement['signatureModal']) {
+    return;
+  }
+
   const toolGroup =
     selectors.getToolButtonObject(getState(), toolName)?.group || '';
 
@@ -13,8 +21,8 @@ export default (store, toolName) => {
   } else {
     dispatch(actions.closeElement('toolsOverlay'));
   }
-
   const hasToolBeenSelected = core.getToolMode().name === toolName;
+
   if (hasToolBeenSelected && toolStylesExist(toolName)) {
     dispatch(actions.toggleElement('toolStylePopup'));
     return;

--- a/src/helpers/setToolModeAndGroup.js
+++ b/src/helpers/setToolModeAndGroup.js
@@ -5,7 +5,6 @@ import selectors from 'selectors';
 
 export default (store, toolName) => {
   const { dispatch, getState } = store;
-
   const toolGroup =
     selectors.getToolButtonObject(getState(), toolName)?.group || '';
 
@@ -15,12 +14,12 @@ export default (store, toolName) => {
     dispatch(actions.closeElement('toolsOverlay'));
   }
 
-  const hasToolBeenSelected = selectors.getOpenElements(getState()) === toolName;
+  const hasToolBeenSelected = core.getToolMode().name === toolName;
   if (hasToolBeenSelected && toolStylesExist(toolName)) {
     dispatch(actions.toggleElement('toolStylePopup'));
     return;
   }
- 
+
   if (
     window.innerWidth <= 900 &&
     // TODO: revisit

--- a/src/helpers/setToolModeAndGroup.js
+++ b/src/helpers/setToolModeAndGroup.js
@@ -6,14 +6,6 @@ import selectors from 'selectors';
 export default (store, toolName) => {
   const { dispatch, getState } = store;
 
-  const openElements = selectors.getOpenElements(getState());
-  const currentTool = core.getToolMode().name;
-
-  if (currentTool === window.Tools.ToolNames.SIGNATURE && openElements['signatureModal']) {
-    // disable changing tool when the signature overlay is opened
-    return;
-  }
-
   const toolGroup =
     selectors.getToolButtonObject(getState(), toolName)?.group || '';
 
@@ -23,12 +15,12 @@ export default (store, toolName) => {
     dispatch(actions.closeElement('toolsOverlay'));
   }
 
-  const hasToolBeenSelected = currentTool === toolName;
+  const hasToolBeenSelected = selectors.getOpenElements(getState()) === toolName;
   if (hasToolBeenSelected && toolStylesExist(toolName)) {
     dispatch(actions.toggleElement('toolStylePopup'));
     return;
   }
-
+ 
   if (
     window.innerWidth <= 900 &&
     // TODO: revisit

--- a/src/helpers/setToolModeAndGroup.js
+++ b/src/helpers/setToolModeAndGroup.js
@@ -22,6 +22,7 @@ export default (store, toolName) => {
   } else {
     dispatch(actions.closeElement('toolsOverlay'));
   }
+  
   const hasToolBeenSelected = currentTool === toolName;
   if (hasToolBeenSelected && toolStylesExist(toolName)) {
     dispatch(actions.toggleElement('toolStylePopup'));


### PR DESCRIPTION
After the signature pop up show up, users can use hot keys to change the current tool. So it's possible for the signature modal to be displayed when the active tool has been change. If the user than click "create", there will be a signature preview even when the tool has already changed

![EnteringErrorState](https://user-images.githubusercontent.com/45575633/80446563-006beb80-88cc-11ea-9bc7-a7df5af93334.gif)

My fix disable changing tools when the signature overlay is opened. I don't think there are any other cases similar to this one (is there?)