### PR TITLE
fix(MeasurementOverlay): only focus the input element when it's not a mobile device

### DIFF
--- a/src/components/MeasurementOverlay/EllipseMeasurementOverlay.js
+++ b/src/components/MeasurementOverlay/EllipseMeasurementOverlay.js
@@ -5,6 +5,7 @@ import Icon from 'components/Icon';
 import core from 'core';
 import getClassName from 'helpers/getClassName';
 import { mapAnnotationToKey, getDataWithKey } from '../../constants/map';
+import { isMobileDevice } from 'src/helpers/device';
 
 function EllipseMeasurementOverlay(props) {
   const { t, annotation, isOpen } = props;
@@ -130,7 +131,7 @@ function EllipseMeasurementOverlay(props) {
       <div className="measurement__value">
         {t('option.measurementOverlay.radius')}:
         <input
-          autoFocus
+          autoFocus={!isMobileDevice}
           className="lineMeasurementInput"
           type="number"
           min="0"

--- a/src/components/MeasurementOverlay/LineMeasurementInput.js
+++ b/src/components/MeasurementOverlay/LineMeasurementInput.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import core from 'core';
+import { isMobileDevice } from 'helpers/device';
 
 function LineMeasurementInput(props) {
   const { t, annotation, isOpen } = props;
@@ -137,7 +138,7 @@ function LineMeasurementInput(props) {
           type="number"
           min="0"
           value={length}
-          autoFocus
+          autoFocus={!isMobileDevice}
           onChange={event => {
             onInputChanged(event);
             selectAnnotation();


### PR DESCRIPTION
Mobile device will bring up the keyboard when an input is focused. This will shift the document container up and make it harder to finish creating an annotation.

@bollain  Let me know if this is ok. The lint is failing which I will fix soon!