### PR TITLE
doc: explicitly mention that disableTools uses disableElements internally, and state the difference between them

### DIFF
--- a/src/apis/disableTools.js
+++ b/src/apis/disableTools.js
@@ -1,5 +1,5 @@
 /**
- * Disable multiple tools.
+ * Disable multiple tools. This API uses disableElements internally to remove tool buttons from the DOM, and also disable the corresponding hotkeys.
  * @method WebViewerInstance#disableTools
  * @param {Array.<string>} [toolNames=all tools] Array of name of the tools, either from tool names list or the name you registered your custom tool with. If nothing is passed, all tools will be disabled.
  * @example


### PR DESCRIPTION
@achenPDFTron Hopefully this clears things a bit, let me know if you have any suggestions.