### PR TITLE
Fix issue where if there was no active search result then clicking th…

### DIFF
--- a/src/components/SearchOverlay/SearchOverlay.js
+++ b/src/components/SearchOverlay/SearchOverlay.js
@@ -331,7 +331,7 @@ class SearchOverlay extends React.PureComponent {
       if (results.length === 0) {
         return;
       }
-      const prevResultIndex = activeResultIndex === 0 ? results.length - 1 : activeResultIndex - 1;
+      const prevResultIndex = activeResultIndex <= 0 ? results.length - 1 : activeResultIndex - 1;
       setActiveResultIndex(prevResultIndex);
       core.setActiveSearchResult(results[prevResultIndex]);
     } else {


### PR DESCRIPTION
…e previous button would go to negative numbers

This could happen when programmatically setting search results and the activeResultIndex was -1 in that case.