### PR TITLE
[Update] Enable selecting thumbnails by default

### DIFF
--- a/src/helpers/setDefaultDisabledElements.js
+++ b/src/helpers/setDefaultDisabledElements.js
@@ -73,7 +73,6 @@ export default store => {
         'layersPanelButton',
         'bookmarksPanel',
         'bookmarksPanelButton',
-        'documentControl',
       ],
       PRIORITY_ONE,
     ),

--- a/src/redux/initialState.js
+++ b/src/redux/initialState.js
@@ -184,7 +184,7 @@ export default {
     isMultipleViewerMerging: false,
     isThumbnailMerging: true,
     isThumbnailReordering: true,
-    isThumbnailMultiselect: false,
+    isThumbnailMultiselect: true,
     allowPageNavigation: true,
     doesAutoLoad: getHashParams('auto_load', true),
     isReadOnly: getHashParams('readonly', false),


### PR DESCRIPTION
Same as #608 , enable selecting pages and the "document controls" by default