### PR TITLE
fix: 2 issues with mentions

### DIFF
--- a/src/apis/mentions.js
+++ b/src/apis/mentions.js
@@ -1,5 +1,5 @@
 import core from 'core';
-import MentionsManager from 'helpers/MentionsManager';
+import mentionsManager from 'helpers/MentionsManager';
 
 /**
  * An instance of MentionsManager that can be used to allow mentioning people in a textarea in the notes panel.
@@ -9,7 +9,7 @@ import MentionsManager from 'helpers/MentionsManager';
  */
 
 export default store => {
-  const mentionsManager = new MentionsManager(store, core.getAnnotationManager());
+  mentionsManager.initialize(store, core.getAnnotationManager());
 
   return expose(mentionsManager, [
     'setUserData',

--- a/src/components/NoteContent/ContentArea/ContentArea.js
+++ b/src/components/NoteContent/ContentArea/ContentArea.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from 'react';
+import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
@@ -6,17 +7,17 @@ import { useTranslation } from 'react-i18next';
 import NoteTextarea from 'components/NoteTextarea';
 
 import core from 'core';
+import mentionsManager from 'helpers/MentionsManager';
+import selectors from 'selectors';
 
 // a component that contains the content textarea, the save button and the cancel button
-const ContentArea = ({
-  annotation,
-  setIsEditing,
-  textAreaValue,
-  onTextAreaValueChange,
-}) => {
-  const contents = annotation.getContents();
+const ContentArea = ({ annotation, setIsEditing, textAreaValue, onTextAreaValueChange }) => {
+  const [isMentionEnabled] = useSelector(state => [
+    selectors.getIsMentionEnabled(state),
+  ]);
   const [t] = useTranslation();
   const textareaRef = useRef();
+  const contents = annotation.getCustomData('trn-mention')?.contents || annotation.getContents();
 
   useEffect(() => {
     // on initial mount, focus the last character of the textarea
@@ -33,19 +34,28 @@ const ContentArea = ({
     e.preventDefault();
 
     const hasEdited = textAreaValue !== contents;
-    if (hasEdited) {
-      setIsEditing(false);
+    if (!hasEdited) {
+      return;
+    }
 
+    setIsEditing(false);
+
+    if (isMentionEnabled) {
+      const { plainTextValue, ids } = mentionsManager.extractMentionDataFromStr(textAreaValue);
+
+      annotation.setCustomData('trn-mention', {
+        contents: textAreaValue,
+        ids,
+      });
+      core.setNoteContents(annotation, plainTextValue);
+    } else {
       core.setNoteContents(annotation, textAreaValue);
-      if (annotation instanceof window.Annotations.FreeTextAnnotation) {
-        core.drawAnnotationsFromList([annotation]);
-      }
+    }
+
+    if (annotation instanceof window.Annotations.FreeTextAnnotation) {
+      core.drawAnnotationsFromList([annotation]);
     }
   };
-
-  const saveBtnClass = classNames({
-    disabled: textAreaValue === contents,
-  });
 
   return (
     <div className="edit-content">
@@ -60,7 +70,12 @@ const ContentArea = ({
         placeholder={`${t('action.comment')}...`}
       />
       <span className="buttons">
-        <button className={saveBtnClass} onMouseDown={setContents}>
+        <button
+          className={classNames({
+            disabled: textAreaValue === contents,
+          })}
+          onMouseDown={setContents}
+        >
           {t('action.save')}
         </button>
         <button

--- a/src/components/NoteContent/NoteContent.js
+++ b/src/components/NoteContent/NoteContent.js
@@ -38,7 +38,9 @@ const NoteContent = ({ annotation }) => {
     NoteContext,
   );
   const [isEditing, setIsEditing] = useState(false);
-  const [textAreaValue, setTextAreaValue] = useState(annotation.getContents());
+  const [textAreaValue, setTextAreaValue] = useState(
+    annotation.getCustomData('trn-mention')?.contents || annotation.getContents()
+  );
   const [t] = useTranslation();
   const dispatch = useDispatch();
 

--- a/src/components/NoteTextarea/AutoResizeTextarea/AutoResizeTextarea.js
+++ b/src/components/NoteTextarea/AutoResizeTextarea/AutoResizeTextarea.js
@@ -48,9 +48,7 @@ const AutoResizeTextarea = React.forwardRef(
           textareaRef.current = el;
           forwardedRef(el);
         }}
-        onChange={e => {
-          onChange(e.target.value);
-        }}
+        onChange={onChange}
         onKeyDown={onKeyDown}
         onFocus={onFocus}
         onBlur={onBlur}

--- a/src/components/NoteTextarea/MentionsTextarea/MentionsTextarea.js
+++ b/src/components/NoteTextarea/MentionsTextarea/MentionsTextarea.js
@@ -38,7 +38,6 @@ const MentionsTextarea = React.forwardRef(
       ...userData.map(data => ({
         ...data,
         display: data.value,
-        id: data.id || data.value,
       })),
     ];
 
@@ -48,9 +47,7 @@ const MentionsTextarea = React.forwardRef(
           className="mention"
           inputRef={forwardedRef}
           value={value}
-          onChange={(fakeEvent, _, plainTextValue) => {
-            onChange(plainTextValue);
-          }}
+          onChange={onChange}
           onKeyDown={onKeyDown}
           onBlur={onBlur}
           onFocus={onFocus}

--- a/src/components/NoteTextarea/NoteTextarea.js
+++ b/src/components/NoteTextarea/NoteTextarea.js
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useRef, useContext } from 'react';
+import React, { useLayoutEffect, useRef, useContext, useImperativeHandle } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector, shallowEqual } from 'react-redux';
 
@@ -23,7 +23,7 @@ const propTypes = {
 };
 
 const MentionsTextarea = React.lazy(() =>
-  import(/* webpackChunkName: 'mention' */'components/NoteTextarea/MentionsTextarea'),
+  import(/* webpackChunkName: 'mention' */ 'components/NoteTextarea/MentionsTextarea')
 );
 
 const NoteTextarea = React.forwardRef((props, forwardedRef) => {
@@ -52,8 +52,8 @@ const NoteTextarea = React.forwardRef((props, forwardedRef) => {
     }
   };
 
-  const handleChange = value => {
-    props.onChange(value);
+  const handleChange = e => {
+    props.onChange(e.target.value);
   };
 
   const textareaProps = {

--- a/src/helpers/MentionsManager.js
+++ b/src/helpers/MentionsManager.js
@@ -1,3 +1,4 @@
+import core from 'core';
 import actions from 'actions';
 import selectors from 'selectors';
 
@@ -31,7 +32,7 @@ import selectors from 'selectors';
  * @extends EventHandler
  */
 class MentionsManager {
-  constructor(store, annotManager) {
+  initialize(store, annotManager) {
     this.store = store;
     /**
      * the key represents the event name
@@ -83,7 +84,7 @@ class MentionsManager {
     let newMentions = [];
 
     annotations.forEach(annotation => {
-      const mentionData = this.extractMentionData(annotation);
+      const mentionData = this.extractMentionDataFromAnnot(annotation);
 
       this.idMentionDataMap[annotation.Id] = mentionData;
       newMentions = newMentions.concat(mentionData.mentions);
@@ -104,7 +105,7 @@ class MentionsManager {
         mentions: [],
         contentWithoutMentions: '',
       };
-      const currMentionData = this.extractMentionData(annotation);
+      const currMentionData = this.extractMentionDataFromAnnot(annotation);
       const prevMentions = prevMentionData.mentions;
       const currMentions = currMentionData.mentions;
 
@@ -163,24 +164,63 @@ class MentionsManager {
   }
 
   /**
+   * @param {string} str a string to extract mention data from
+   * @returns {object} returns an object that contains the following properties
+   * plainTextValue: a string that has been transformed to not have the markups in the incoming string
+   * ids: an array of strings that contains the mentioned ids
+   * @ignore
+   */
+  extractMentionDataFromStr(str) {
+    // the value of the markup is defined at https://github.com/signavio/react-mentions#configuration
+    const markupRegex = /@\[(.*?)\]\((.*?)\)/g;
+    const ids = [];
+    let match;
+    let plainTextValue = str;
+
+    window.str11 = str;
+    // iterate through the matches, extract ids and build the plainTextValue
+    // after the iteration finishes, if the incoming string is Hello! @[Zhijie Zhang](zzhang@pdftron.com), then we should have:
+    // {
+    //   plainTextValue: Hello! Zhijie Zhang,
+    //   ids: ['zzhang@pdftron.com'],
+    // }
+    while ((match = markupRegex.exec(str)) !== null) {
+      const [wholeMatch, displayName, id] = match;
+
+      ids.push(id);
+      plainTextValue = plainTextValue.replace(
+        // keep the @ and only replace the remaining text
+        wholeMatch.slice(1),
+        displayName,
+      );
+    }
+
+    return {
+      plainTextValue,
+      ids,
+    };
+  }
+
+  /**
    * @param {string} content
    * @returns {mentionData}
    * @ignore
    */
-  extractMentionData(annotation) {
-    const content = annotation.getContents();
+  extractMentionDataFromAnnot(annotation) {
+    const mentionData = annotation.getCustomData('trn-mention');
     const userData = this.getUserData();
+    const contents = annotation.getContents();
     const result = {
       mentions: [],
-      contentWithoutMentions: content,
+      contentWithoutMentions: contents,
     };
 
-    if (!content) {
+    if (!mentionData) {
       return result;
     }
 
     userData.forEach(user => {
-      if (this.includesMention(content, user.value)) {
+      if (mentionData.ids.includes(user.id) && this.isValidMention(contents, user.value)) {
         result.mentions.push({
           ...user,
           annotId: annotation.Id,
@@ -193,14 +233,10 @@ class MentionsManager {
     return result;
   }
 
-  includesMention(content, value) {
+  isValidMention(content, value) {
     value = `@${value}`;
+
     const startIndex = content.indexOf(value);
-
-    if (startIndex === -1) {
-      return;
-    }
-
     const nextChar = content[startIndex + value.length];
     const isEndOfString = typeof nextChar === 'undefined';
     const allowedChars = this.getAllowedTrailingCharacters();
@@ -216,6 +252,26 @@ class MentionsManager {
     }
 
     return true;
+  }
+
+  createMentionReply(annotation, value) {
+    const { plainTextValue, ids } = this.extractMentionDataFromStr(value);
+
+    const replyAnnot = new Annotations.StickyAnnotation();
+    replyAnnot['InReplyTo'] = annotation['Id'];
+    replyAnnot['X'] = annotation['X'];
+    replyAnnot['Y'] = annotation['Y'];
+    replyAnnot['PageNumber'] = annotation['PageNumber'];
+    replyAnnot['Author'] = core.getCurrentUser();
+    replyAnnot.setContents(plainTextValue || '');
+    replyAnnot.setCustomData('trn-mention', {
+      contents: value,
+      ids,
+    });
+
+    annotation.addReply(replyAnnot);
+
+    core.addAnnotations([replyAnnot]);
   }
 
   /**
@@ -237,6 +293,11 @@ WebViewer(...)
   });
    */
   setUserData(userData) {
+    userData = userData.map(user => ({
+      ...user,
+      id: user.id || user.email || user.value,
+    }));
+
     this.store.dispatch(actions.setUserData(userData));
   }
 
@@ -380,4 +441,7 @@ WebViewer(...)
  * @param {'add'|'modify'|'delete'} action The action that occurred (add, delete, modify)
  */
 
-export default MentionsManager;
+export default new MentionsManager();
+export {
+  MentionsManager
+};

--- a/src/helpers/MentionsManager.js
+++ b/src/helpers/MentionsManager.js
@@ -177,7 +177,6 @@ class MentionsManager {
     let match;
     let plainTextValue = str;
 
-    window.str11 = str;
     // iterate through the matches, extract ids and build the plainTextValue
     // after the iteration finishes, if the incoming string is Hello! @[Zhijie Zhang](zzhang@pdftron.com), then we should have:
     // {

--- a/src/redux/selectors/exposedSelectors.js
+++ b/src/redux/selectors/exposedSelectors.js
@@ -122,6 +122,8 @@ export const getMaxSignaturesCount = state => state.viewer.maxSignaturesCount;
 
 export const getUserData = state => state.viewer.userData;
 
+export const getIsMentionEnabled = state => !!state.viewer.userData;
+
 export const getSignatureFonts = state => state.viewer.signatureFonts;
 
 export const getSelectedTab = (state, id) => state.viewer.tab[id];


### PR DESCRIPTION

1. fixes #604 - Mentions should use a unique ID for selection. This issue is fixed by adding user ids to annotations' custom data, and retrieve them instead of user values(names) to determine when mentions have been added/modified/deleted.
2. fixes an issue where deleting a mention in the editing mode didn't delete the whole mention at once. This issue was caused by us just passing the plain text value to the mentions input, where the text with markup should be passed to it