### PR TITLE
[Bugfix] Fix header overlay being offscreen

### DIFF
--- a/src/helpers/getOverlayPositionBasedOn.js
+++ b/src/helpers/getOverlayPositionBasedOn.js
@@ -39,5 +39,5 @@ export default (element, overlay, align = 'left') => {
     right = 'auto';
     left = buttonLeft - (overlayWidth - buttonWidth);
   }
-  return { left, right };
+  return { left: Math.max(left, 0), right };
 };

--- a/src/helpers/getOverlayPositionBasedOn.js
+++ b/src/helpers/getOverlayPositionBasedOn.js
@@ -39,5 +39,10 @@ export default (element, overlay, align = 'left') => {
     right = 'auto';
     left = buttonLeft - (overlayWidth - buttonWidth);
   }
-  return { left: Math.max(left, 0), right };
+
+
+  return { 
+    left: !isNaN(left) ? Math.max(left, 0) : left,
+    right
+  };
 };


### PR DESCRIPTION
This is for this bug

https://trello.com/c/YSdveJrl/1021-ui-releated-bug-signature-overlay-is-off

We prevent the header from having a left offset that is negative so it won't go offscreen