### PR TITLE
feat(MeasurementOverlay): allow creation and editing measurement annotations underneath the measurement overlay

### DIFF
--- a/src/components/MeasurementOverlay/CustomMeasurementOverlay.js
+++ b/src/components/MeasurementOverlay/CustomMeasurementOverlay.js
@@ -52,7 +52,7 @@ function CustomEllipseMeasurementOverlay(props) {
   };
 
   return (
-    <div className="Overlay MeasurementOverlay open" data-element="measurementOverlay">
+    <>
       <div className="measurement__title">
         {icon && <Icon className="measurement__icon" glyph={icon} />}
         {props.title}
@@ -66,7 +66,7 @@ function CustomEllipseMeasurementOverlay(props) {
       <div className="measurement__value">
         {props.label}: <input className="lineMeasurementInput" type="number" min="0" value={computeRadius()} onChange={event => props.onChange(event, props.annotation)}/> {unit}
       </div>
-    </div>
+    </>
   );
 }
 

--- a/src/components/MeasurementOverlay/EllipseMeasurementOverlay.js
+++ b/src/components/MeasurementOverlay/EllipseMeasurementOverlay.js
@@ -7,7 +7,6 @@ import Icon from 'components/Icon';
 
 import core from 'core';
 import selectors from 'selectors';
-import getClassName from 'helpers/getClassName';
 import { mapAnnotationToKey, getDataWithKey } from '../../constants/map';
 import { isMobileDevice } from 'src/helpers/device';
 
@@ -19,7 +18,6 @@ function EllipseMeasurementOverlay(props) {
   const scale = annotation.Scale;
   const precision = annotation.Precision;
   const unit = annotation.Scale[1][1];
-  const className = getClassName('Overlay MeasurementOverlay', { isOpen });
   const renderScaleRatio = () => `${scale[0][0]} ${scale[0][1]} = ${scale[1][0]} ${scale[1][1]}`;
 
   useEffect(() => {
@@ -119,7 +117,7 @@ function EllipseMeasurementOverlay(props) {
   const [ radius, setRadius ] = useState(computeRadius());
 
   return (
-    <div className={className} data-element="measurementOverlay">
+    <>
       <div className="measurement__title">
         {icon && <Icon className="measurement__icon" glyph={icon}/>}
         {t('option.measurementOverlay.areaMeasurement')}
@@ -155,7 +153,7 @@ function EllipseMeasurementOverlay(props) {
           }}
         /> {unit}
       </div>
-    </div>
+    </>
   );
 }
 

--- a/src/components/MeasurementOverlay/MeasurementOverlay.scss
+++ b/src/components/MeasurementOverlay/MeasurementOverlay.scss
@@ -21,6 +21,11 @@
   & > * {
     margin: 6px;
   }
+
+  &.transparent {
+    opacity: 0.5;
+    pointer-events: none;
+  }
 }
 
 .measurement__title {


### PR DESCRIPTION
The purpose of this PR is to address the second feedback from https://github.com/PDFTron/webviewer-ui/issues/610.

This PR does two things:
1. Make the measurement overlay component draggable, so users will be able to move it around in the view to find a comfortable spot.
2. Make the component transparent when
    - we are creating an annotation and our mouse is hovering the component
    - we are selecting an annotation and our mouse is hovering on the part of the annotation that's under the component
Before this PR, a user won't be able to create a path point under the component for polyline and polygon annotations, which I see can be a bit annoying.

Also some of the code is formatted.

@bollain Could you take a look when you have time? Just want to see if you have any feedback.