### PR TITLE
Fix issue where pasting into a freetext when zoomed in would scroll the viewer to the left

### DIFF
--- a/src/constants/quill.scss
+++ b/src/constants/quill.scss
@@ -23,10 +23,10 @@
 }
 
 .ql-clipboard {
-  position: absolute;
+  position: fixed;
   height: 1px;
   top: 50%;
-  left: -100000px;
+  left: 50%;
   overflow-y: hidden;
 
   p {


### PR DESCRIPTION
This would happen because the clipboard became focused and was far off to the left of the page