### PR TITLE
[Update] Added API to set the available palettes for a certain tool

### DIFF
--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -86,6 +86,7 @@ import setActiveLeftPanel from './setActiveLeftPanel';
 import setAdminUser from './setAdminUser';
 import setAnnotationUser from './setAnnotationUser';
 import setActivePalette from './setActivePalette';
+import setAvailablePalettes from './setAvailablePalettes';
 import setColorPalette from './setColorPalette';
 import setCurrentPageNumber from './setCurrentPageNumber';
 import setCustomNoteFilter from './setCustomNoteFilter';
@@ -253,6 +254,7 @@ export default store => {
     setShowSideWindow: setShowSideWindow(store),
     setSideWindowVisibility: setSideWindowVisibility(store),
     setActivePalette: setActivePalette(store),
+    setAvailablePalettes: setAvailablePalettes(store),
     setColorPalette: setColorPalette(store),
     disableTool: disableTool(store),
     enableAllElements: enableAllElements(store),

--- a/src/apis/setAvailablePalettes.js
+++ b/src/apis/setAvailablePalettes.js
@@ -1,0 +1,42 @@
+import { mapToolNameToKey } from 'constants/map';
+import mapPaletteToAnnotationColorProperty from 'constants/mapPaletteToAnnotationColorProperty';
+import actions from 'actions';
+import selectors from 'selectors';
+import setActivePalette from './setActivePalette';
+
+/**
+ * ???
+ * @method WebViewerInstance#setAvailablePalettes
+ * @param {string[]} colorPalettes An array of palettes that are available for a particular tool. Contains one of 'text', 'border' and 'fill'.
+ * @example
+WebViewer(...)
+  .then(function(instance) {
+    instance.setAvailablePalettes('AnnotationCreateRectangle', ['text', 'border', 'fill']);
+  });
+ */
+
+export default store => (toolName, colorPalettes) => {
+  if (!colorPalettes) {
+    console.warn(`${toolName} is not a valid tool name!`);
+    return;
+  }
+
+  const currentOverride = {
+    ...(selectors.getCustomElementOverrides(store.getState(), 'availablePalettes') || {}),
+  };
+
+  const key = mapToolNameToKey(toolName);
+  if (!toolName || !key) {
+    console.warn(`${toolName} is not a valid tool name!`);
+    return;
+  }
+  const currentPalette = selectors.getCurrentPalette(store.getState(), key);
+  const availablePalettes = colorPalettes.map(palette => mapPaletteToAnnotationColorProperty[palette]);
+  currentOverride[key] = availablePalettes;
+
+  if (availablePalettes.length > 0 && !availablePalettes.includes(currentPalette)) {
+    setActivePalette(store)(toolName, colorPalettes[0]);
+  }
+
+  store.dispatch(actions.setCustomElementOverrides('availablePalettes', currentOverride));
+};

--- a/src/apis/setAvailablePalettes.js
+++ b/src/apis/setAvailablePalettes.js
@@ -18,7 +18,7 @@ WebViewer(...)
 
 export default store => (toolName, colorPalettes) => {
   if (!colorPalettes) {
-    console.warn(`${toolName} is not a valid tool name!`);
+    console.warn(`No palette names were provided: ${colorPalettes}. Please use one of the following: 'text', 'border' and/or 'fill'.`);
     return;
   }
 

--- a/src/apis/setAvailablePalettes.js
+++ b/src/apis/setAvailablePalettes.js
@@ -5,8 +5,9 @@ import selectors from 'selectors';
 import setActivePalette from './setActivePalette';
 
 /**
- * ???
+ * Sets the available palettes for a particular tool
  * @method WebViewerInstance#setAvailablePalettes
+ * @param {string} toolName The tool name.
  * @param {string[]} colorPalettes An array of palettes that are available for a particular tool. Contains one of 'text', 'border' and 'fill'.
  * @example
 WebViewer(...)

--- a/src/components/ColorPalette/ColorPalette.js
+++ b/src/components/ColorPalette/ColorPalette.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { getDataWithKey } from 'constants/map';
 
 import getBrightness from 'helpers/getBrightness';
 import selectors from 'selectors';
@@ -16,6 +17,7 @@ class ColorPalette extends React.PureComponent {
     color: PropTypes.object,
     onStyleChange: PropTypes.func.isRequired,
     overridePalette: PropTypes.array,
+    overrideAvailablePalettes: PropTypes.object,
   }
 
   constructor(props) {
@@ -69,11 +71,17 @@ class ColorPalette extends React.PureComponent {
   }
 
   render() {
-    const { hasPadding, style = {}, property, color, overridePalette, overridePalette2 } = this.props;
+    const { hasPadding, style = {}, colorMapKey, property, color, overridePalette, overridePalette2, overrideAvailablePalettes } = this.props;
 
     const allowTransparent = !(property === 'TextColor' || property === 'StrokeColor');
 
     const palette = overridePalette2 || overridePalette || this.palette;
+
+    const availablePalettes = overrideAvailablePalettes?.[colorMapKey] || getDataWithKey(colorMapKey).availablePalettes;
+
+    if (availablePalettes && !availablePalettes.includes(property)) {
+      return null;
+    }
 
     return (
       <div
@@ -143,6 +151,7 @@ class ColorPalette extends React.PureComponent {
 
 const mapStateToProps = state => ({
   overridePalette: selectors.getCustomElementOverrides(state, dataElement),
+  overrideAvailablePalettes: selectors.getCustomElementOverrides(state, 'availablePalettes'),
 });
 
 export default connect(mapStateToProps)(ColorPalette);

--- a/src/components/ColorPaletteHeader/ColorPaletteHeader.js
+++ b/src/components/ColorPaletteHeader/ColorPaletteHeader.js
@@ -20,6 +20,7 @@ class ColorPaletteHeader extends React.PureComponent {
     isTextColorPaletteDisabled: PropTypes.bool,
     isFillColorPaletteDisabled: PropTypes.bool,
     isBorderColorPaletteDisabled: PropTypes.bool,
+    overrideAvailablePalettes: PropTypes.object,
   }
 
   setActivePalette = newPalette => {
@@ -37,8 +38,10 @@ class ColorPaletteHeader extends React.PureComponent {
       isTextColorPaletteDisabled,
       isBorderColorPaletteDisabled,
       isFillColorPaletteDisabled,
+      overrideAvailablePalettes,
     } = this.props;
     const { availablePalettes } = getDataWithKey(colorMapKey);
+    const localAvailablePalettes = overrideAvailablePalettes?.[colorMapKey] || overrideAvailablePalettes?.global || availablePalettes;
 
     if (toolName && (toolName.includes('Line') || toolName.includes('Arrow') || toolName.includes('Polyline'))) {
       return (
@@ -62,7 +65,7 @@ class ColorPaletteHeader extends React.PureComponent {
     }
 
 
-    if (availablePalettes.length < 2) {
+    if (localAvailablePalettes.length < 2) {
       return null;
     }
 
@@ -72,7 +75,7 @@ class ColorPaletteHeader extends React.PureComponent {
 
     return (
       <div className="palette-options">
-        {availablePalettes.map((pallette, i) =>
+        {localAvailablePalettes.map((pallette, i) =>
           <React.Fragment key={i}>
             <div
               className={classNames({
@@ -83,7 +86,7 @@ class ColorPaletteHeader extends React.PureComponent {
             >
               {t(`option.annotationColor.${pallette}`)}
             </div>
-            {i < availablePalettes.length - 1 && <div className="palette-options-divider" />}
+            {i < localAvailablePalettes.length - 1 && <div className="palette-options-divider" />}
           </React.Fragment>,
         )}
       </div>
@@ -95,6 +98,7 @@ const mapStateToProps = state => ({
   isTextColorPaletteDisabled: selectors.isElementDisabled(state, 'textColorPalette'),
   isFillColorPaletteDisabled: selectors.isElementDisabled(state, 'fillColorPalette'),
   isBorderColorPaletteDisabled: selectors.isElementDisabled(state, 'borderColorPalette'),
+  overrideAvailablePalettes: selectors.getCustomElementOverrides(state, 'availablePalettes'),
 });
 
 const mapDispatchToProps = {


### PR DESCRIPTION
Originated from a request from a customer to be able to disable the border style palette and stroke thickness slider only for a rectangle.

![availablePalette](https://user-images.githubusercontent.com/25498512/83596703-2bc0a680-a51a-11ea-9719-022880fea16a.gif)
