### PR TITLE
Add API to customize annotation tooltips

### DIFF
--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -136,6 +136,7 @@ import selectThumbnailPages from './selectThumbnailPages';
 import unselectThumbnailPages from './unselectThumbnailPages';
 import setSearchResults from './setSearchResults';
 import setActiveResult from './setActiveResult';
+import setAnnotationContentOverlayHandler from './setAnnotationContentOverlayHandler';
 
 export default store => {
   window.readerControl = {
@@ -217,6 +218,7 @@ export default store => {
     getSelectedThumbnailPageNumbers: getSelectedThumbnailPageNumbers(store),
     selectThumbnailPages: selectThumbnailPages(store),
     unselectThumbnailPages: unselectThumbnailPages(store),
+    setAnnotationContentOverlayHandler: setAnnotationContentOverlayHandler(store),
 
     // undocumented and deprecated, to be removed in 7.0
     closeElement: closeElement(store),

--- a/src/apis/setAnnotationContentOverlayHandler.js
+++ b/src/apis/setAnnotationContentOverlayHandler.js
@@ -1,5 +1,22 @@
 import action from 'actions';
 
+/**
+ * Adds a custom overlay to annotations if that annotation currently support it. Currently only the Ellipsis annotation supports it.
+ * @method WebViewerInstance#setAnnotationContentOverlayHandler
+ * @param {function} customOverlayHandler a function that takes an annotation and returns a DOM Element, which is rendered as a tooltip when hovering over the annotation
+ *  * @example
+WebViewer(...)
+  .then(function(instance) {
+    instance.setAnnotationContentOverlayHandler(annotation => {
+        var div = document.createElement("div")
+        div.appendChild(document.createTextNode(`Created by: ${annotation.Author}`))
+        div.appendChild(document.createElement('br'))
+        div.appendChild(document.createTextNode(`Created on ${annotation.DateCreated}`))
+        return div
+    })
+  });
+ */
+
 export default store => annotationContentOverlayHandler => {
   store.dispatch(action.setAnnotationContentOverlayHandler(annotationContentOverlayHandler));
 };

--- a/src/apis/setAnnotationContentOverlayHandler.js
+++ b/src/apis/setAnnotationContentOverlayHandler.js
@@ -1,19 +1,19 @@
 import action from 'actions';
 
 /**
- * Adds a custom overlay to annotations if that annotation currently support it. Currently only the Ellipsis annotation supports it.
+ * Adds a custom overlay to annotations on mouseHover, overriding the existing overlay.
  * @method WebViewerInstance#setAnnotationContentOverlayHandler
  * @param {function} customOverlayHandler a function that takes an annotation and returns a DOM Element, which is rendered as a tooltip when hovering over the annotation
  *  * @example
 WebViewer(...)
   .then(function(instance) {
     instance.setAnnotationContentOverlayHandler(annotation => {
-        var div = document.createElement("div")
-        div.appendChild(document.createTextNode(`Created by: ${annotation.Author}`))
-        div.appendChild(document.createElement('br'))
-        div.appendChild(document.createTextNode(`Created on ${annotation.DateCreated}`))
-        return div
-    })
+        const div = document.createElement('div');
+        div.appendChild(document.createTextNode(`Created by: ${annotation.Author}`));
+        div.appendChild(document.createElement('br'));
+        div.appendChild(document.createTextNode(`Created on ${annotation.DateCreated}`));
+        return div;
+    });
   });
  */
 

--- a/src/apis/setAnnotationContentOverlayHandler.js
+++ b/src/apis/setAnnotationContentOverlayHandler.js
@@ -1,0 +1,5 @@
+import action from 'actions';
+
+export default store => annotationContentOverlayHandler => {
+  store.dispatch(action.setAnnotationContentOverlayHandler(annotationContentOverlayHandler));
+};

--- a/src/components/AnnotationContentOverlay/AnnotationContentOverlay.js
+++ b/src/components/AnnotationContentOverlay/AnnotationContentOverlay.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
@@ -64,39 +65,58 @@ const AnnotationContentOverlay = () => {
   const contents = annotation?.getContents();
   const numberOfReplies = annotation?.getReplies().length;
 
-  if (annotation && isUsingCustomHandler) {
-    return (
-      <div
-        className="Overlay AnnotationContentOverlay"
-        data-element="annotationContentOverlay"
-        style={{ ...overlayPosition }}
-      >
-        <CustomElement
-          render={() => customHandler(annotation)}
-        />
-      </div>
-    );
-  }
-
-  return isDisabled || isMobileDevice || !contents ? null : (
+  const OverlayWrapper = props => (
     <div
       className="Overlay AnnotationContentOverlay"
       data-element="annotationContentOverlay"
       style={{ ...overlayPosition }}
     >
-      <div className="author">{core.getDisplayAuthor(annotation)}</div>
-      <div className="contents">
-        {contents.length > MAX_CHARACTERS
-          ? `${contents.slice(0, MAX_CHARACTERS)}...`
-          : contents}
-      </div>
-      {numberOfReplies > 0 && (
-        <div className="replies">
-          {t('message.annotationReplyCount', { count: numberOfReplies })}
-        </div>
-      )}
+      {props.children}
     </div>
   );
+
+  const CustomOverlay = () => {
+    if (annotation) {
+      return (
+        <OverlayWrapper>
+          <CustomElement render={() => customHandler(annotation)} />
+        </OverlayWrapper>
+      );
+    } else {
+      return null;
+    }
+  };
+
+  const DefaultOverlay = () => {
+    if (contents) {
+      return (
+        <OverlayWrapper>
+          <div className="author">{core.getDisplayAuthor(annotation)}</div>
+          <div className="contents">
+            {contents.length > MAX_CHARACTERS
+              ? `${contents.slice(0, MAX_CHARACTERS)}...`
+              : contents}
+          </div>
+          {numberOfReplies > 0 && (
+            <div className="replies">
+              {t('message.annotationReplyCount', { count: numberOfReplies })}
+            </div>
+          )}
+        </OverlayWrapper>
+      );
+    } else {
+      return null;
+    }
+  };
+
+  if (isDisabled || isMobileDevice) {
+    return null;
+  } else if (isUsingCustomHandler) {
+    return <CustomOverlay />;
+  } else {
+    return <DefaultOverlay />;
+  }
+
 };
 
 export default AnnotationContentOverlay;

--- a/src/components/AnnotationContentOverlay/AnnotationContentOverlay.js
+++ b/src/components/AnnotationContentOverlay/AnnotationContentOverlay.js
@@ -8,6 +8,8 @@ import selectors from 'selectors';
 
 import './AnnotationContentOverlay.scss';
 
+import CustomElement from '../CustomElement';
+
 const MAX_CHARACTERS = 100;
 
 const AnnotationContentOverlay = () => {
@@ -20,6 +22,13 @@ const AnnotationContentOverlay = () => {
     left: 0,
     top: 0,
   });
+
+  // Clients have the option to customize how the tooltip is rendered
+  // by passing a handler
+  const customHandler = useSelector(state =>
+    selectors.getAnnotationContentOverlayHandler(state),
+  );
+  const isUsingCustomHandler = customHandler !== null;
 
   useEffect(() => {
     const onMouseHover = e => {
@@ -54,6 +63,20 @@ const AnnotationContentOverlay = () => {
 
   const contents = annotation?.getContents();
   const numberOfReplies = annotation?.getReplies().length;
+
+  if (annotation && isUsingCustomHandler) {
+    return (
+      <div
+        className="Overlay AnnotationContentOverlay"
+        data-element="annotationContentOverlay"
+        style={{ ...overlayPosition }}
+      >
+        <CustomElement
+          render={() => customHandler(annotation)}
+        />
+      </div>
+    );
+  }
 
   return isDisabled || isMobileDevice || !contents ? null : (
     <div

--- a/src/redux/actions/exposedActions.js
+++ b/src/redux/actions/exposedActions.js
@@ -300,3 +300,7 @@ export const setActiveResultIndex = index => ({
   type: 'SET_ACTIVE_RESULT_INDEX',
   payload: { index },
 });
+export const setAnnotationContentOverlayHandler = annotationContentOverlayHandler => ({
+  type: 'SET_ANNOTATION_CONTENT_OVERLAY_HANDLER',
+  payload: { annotationContentOverlayHandler }
+});

--- a/src/redux/initialState.js
+++ b/src/redux/initialState.js
@@ -357,6 +357,7 @@ export default {
     noteTransformFunction: null,
     savedSignatures: [],
     selectedSignatureIndex: 0,
+    annotationContentOverlayHandler: null
   },
   search: {
     listeners: [],

--- a/src/redux/reducers/viewerReducer.js
+++ b/src/redux/reducers/viewerReducer.js
@@ -335,6 +335,8 @@ export default initialState => (state = initialState, action) => {
       return { ...state, customElementOverrides: { ...state.customElementOverrides, [payload.dataElement]: payload.overrides } };
     case 'SET_NOTE_TRANSFORM_FUNCTION':
       return { ...state, noteTransformFunction: payload.noteTransformFunction };
+    case 'SET_ANNOTATION_CONTENT_OVERLAY_HANDLER':
+      return { ...state, annotationContentOverlayHandler: payload.annotationContentOverlayHandler };
     default:
       return state;
   }

--- a/src/redux/selectors/exposedSelectors.js
+++ b/src/redux/selectors/exposedSelectors.js
@@ -95,7 +95,7 @@ export const getToolButtonDataElements = (state, toolNames) => {
   return toolNames
     .map(toolName => toolButtonObjects[toolName]?.dataElement)
     .filter(Boolean);
-}
+};
 
 export const getToolButtonObject = (state, toolName) =>
   getToolButtonObjects(state)[toolName];
@@ -115,7 +115,7 @@ export const getToolNameByDataElement = (state, dataElement) => {
   return Object.keys(toolButtonObjects).find(
     name => toolButtonObjects[name].dataElement === dataElement,
   );
-}
+};
 
 
 export const getActiveToolName = state => state.viewer.activeToolName;
@@ -212,6 +212,8 @@ export const getIsMultipleViewerMerging = state => state.viewer.isMultipleViewer
 export const getAllowPageNavigation = state => state.viewer.allowPageNavigation;
 
 export const getCustomMeasurementOverlay = state => state.viewer.customMeasurementOverlay;
+
+export const getAnnotationContentOverlayHandler = state => state.viewer.annotationContentOverlayHandler;
 
 // warning message
 export const getWarningMessage = state => state.viewer.warning?.message || '';


### PR DESCRIPTION
Trello card:
https://trello.com/c/OsViPPT3/906-custom-tooltips

Adds new API so users can override current tooltip behaviour on annotations.

API takes a callback that should return a DOM element.
```
Webviewer({
  initialDoc: hashFile,
  path: '/lib',
}, document.getElementById('viewer')).then(instance => {
  instance.setAnnotationContentOverlayHandler(annotation => {
    var div = document.createElement("div")
    div.appendChild(document.createTextNode(`Created by: ${annotation.Author}`))
    div.appendChild(document.createElement('br'))
    div.appendChild(document.createTextNode(`Created on ${annotation.DateCreated}`))
    return div
  })
});
```