### PR TITLE
[6.3][Bugfix] Fixed sliders to use data-element

### DIFF
--- a/src/components/Slider/Slider.js
+++ b/src/components/Slider/Slider.js
@@ -10,6 +10,7 @@ import './Slider.scss';
 class Slider extends React.PureComponent {
   static propTypes = {
     property: PropTypes.string.isRequired,
+    dataElement: PropTypes.string.isRequired,
     value: PropTypes.oneOfType([
       PropTypes.number,
       PropTypes.string,
@@ -109,20 +110,20 @@ class Slider extends React.PureComponent {
   }
 
   renderSlider = () => {
-    const { displayProperty, displayValue, getCirclePosition, t } = this.props;
+    const { dataElement, displayProperty, displayValue, getCirclePosition, t } = this.props;
     const circleCenter = getCirclePosition(this.lineLength);
 
     return (
       <React.Fragment>
-        <div className="slider__property">
+        <div className="slider__property" data-element={dataElement}>
           {t(`option.slider.${displayProperty}`)}
         </div>
-        <svg data-element="slider" width="100%" height={svgHeight} onMouseDown={this.onMouseDown} onTouchStart={this.onTouchStart} ref={this.sliderSvg}>
+        <svg data-element={`slider ${dataElement}`} width="100%" height={svgHeight} onMouseDown={this.onMouseDown} onTouchStart={this.onTouchStart} ref={this.sliderSvg}>
           <line x1={circleRadius} y1="50%" x2={circleCenter} y2="50%" strokeWidth="2" stroke="#00a5e4" strokeLinecap="round" />
           <line x1={circleCenter} y1="50%" x2={this.lineLength + circleRadius} y2="50%" strokeWidth="2" stroke="#e0e0e0" strokeLinecap="round" />
           <circle cx={circleCenter} cy="50%" r={circleRadius} fill="#00a5e4" />
         </svg>
-        <div className="slider__value">
+        <div className="slider__value" data-element={dataElement}>
           {displayValue}
         </div>
       </React.Fragment>

--- a/src/components/StylePopup/StylePopup.js
+++ b/src/components/StylePopup/StylePopup.js
@@ -54,50 +54,44 @@ class StylePopup extends React.PureComponent {
     const lineStart = circleRadius;
     const sliderProps = [];
     if (!isOpacitySliderDisabled) {
-      sliderProps.push(
-        {
-          property: 'Opacity',
-          displayProperty: 'opacity',
-          value: Opacity,
-          displayValue: `${Math.round(Opacity * 100)}%`,
-          getCirclePosition: lineLength => Opacity * lineLength + lineStart,
-          convertRelativeCirclePositionToValue: circlePosition => circlePosition,
-          dataElement: DataElements.OPACITY_SLIDER
-        }
-      );
+      sliderProps[0] = {
+        property: 'Opacity',
+        displayProperty: 'opacity',
+        value: Opacity,
+        displayValue: `${Math.round(Opacity * 100)}%`,
+        getCirclePosition: lineLength => Opacity * lineLength + lineStart,
+        convertRelativeCirclePositionToValue: circlePosition => circlePosition,
+        dataElement: DataElements.OPACITY_SLIDER
+      };
     }
     if (!isStrokeThicknessSliderDisabled) {
-      sliderProps.push(
-        {
-          dataElement: DataElements.STROKE_THICKNESS_SLIDER,
-          property: 'StrokeThickness',
-          displayProperty: 'thickness',
-          value: StrokeThickness,
-          displayValue: `${Math.round(StrokeThickness)}pt`,
-          // FreeText Annotations can have the border thickness go down to 0. For others the minimum is 1.
-          getCirclePosition: lineLength =>
-            (isFreeText
-              ? (StrokeThickness / 20) * lineLength + lineStart
-              : ((StrokeThickness - 1) / 19) * lineLength + lineStart),
-          convertRelativeCirclePositionToValue: circlePosition =>
-            (isFreeText ? circlePosition * 20 : circlePosition * 19 + 1),
-        }
-      );
+      sliderProps[1] = {
+        dataElement: DataElements.STROKE_THICKNESS_SLIDER,
+        property: 'StrokeThickness',
+        displayProperty: 'thickness',
+        value: StrokeThickness,
+        displayValue: `${Math.round(StrokeThickness)}pt`,
+        // FreeText Annotations can have the border thickness go down to 0. For others the minimum is 1.
+        getCirclePosition: lineLength =>
+          (isFreeText
+            ? (StrokeThickness / 20) * lineLength + lineStart
+            : ((StrokeThickness - 1) / 19) * lineLength + lineStart),
+        convertRelativeCirclePositionToValue: circlePosition =>
+          (isFreeText ? circlePosition * 20 : circlePosition * 19 + 1),
+      };
     }
     if (!isFontSizeSliderDisabled) {
-      sliderProps.push(
-        {
-          dataElement: DataElements.FONT_SIZE_SLIDER,
-          property: 'FontSize',
-          displayProperty: 'text',
-          value: FontSize,
-          displayValue: `${Math.round(parseInt(FontSize, 10))}pt`,
-          getCirclePosition: lineLength =>
-            ((parseInt(FontSize, 10) - 5) / 40) * lineLength + lineStart,
-          convertRelativeCirclePositionToValue: circlePosition =>
-            `${circlePosition * 40 + 5}pt`,
-        },
-      );
+      sliderProps[2] = {
+        dataElement: DataElements.FONT_SIZE_SLIDER,
+        property: 'FontSize',
+        displayProperty: 'text',
+        value: FontSize,
+        displayValue: `${Math.round(parseInt(FontSize, 10))}pt`,
+        getCirclePosition: lineLength =>
+          ((parseInt(FontSize, 10) - 5) / 40) * lineLength + lineStart,
+        convertRelativeCirclePositionToValue: circlePosition =>
+          `${circlePosition * 40 + 5}pt`,
+      };
     }
 
     return [Opacity, StrokeThickness, FontSize].map((value, index) => {


### PR DESCRIPTION
Sliders were provided data-element values but were not actually used. This PR should correct that, as well as a bug where disabling one, would cause the next to render due to a mismatch with the slider prop indices.

I could not wrap the sliders in another element to add this data-element since the elements would then not line up in the grid.

![image](https://user-images.githubusercontent.com/25498512/84090570-082cae80-a9a7-11ea-9ec4-d31acc090015.png)

