### PR TITLE
[CHANGE] Fix issue where the aspect ratio of thumbnails wasn't preserved in some cases

### DIFF
--- a/src/components/Thumbnail/Thumbnail.js
+++ b/src/components/Thumbnail/Thumbnail.js
@@ -109,8 +109,10 @@ class Thumbnail extends React.PureComponent {
 
     const id = core.loadThumbnailAsync(pageNum, thumb => {
       thumb.className = 'page-image';
-      thumb.style.maxWidth = `${THUMBNAIL_SIZE}px`;
-      thumb.style.maxHeight = `${THUMBNAIL_SIZE}px`;
+
+      const ratio = Math.min(THUMBNAIL_SIZE / thumb.width, THUMBNAIL_SIZE / thumb.height);
+      thumb.style.width = `${thumb.width * ratio}px`;
+      thumb.style.height = `${thumb.height * ratio}px`;
 
       const childElement = current?.querySelector('.page-image');
       if (childElement) {


### PR DESCRIPTION
The problem was that WebViewer Server creates thumbnails larger than the max size
and using max-width, max-height just fits them to a 150 pixel square.
This code should maintain the aspect ratio

Same as https://github.com/PDFTron/webviewer-ui/pull/663