### PR TITLE
Bugfix/svg missing attributes

### DIFF
--- a/assets/icons/ic_annotation_rectangular_area_black_24px.svg
+++ b/assets/icons/ic_annotation_rectangular_area_black_24px.svg
@@ -1,1 +1,5 @@
-<svg id="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><defs><style>.cls-1{fill:#000000;}</style></defs><title>icon - tool - measurement - area - line</title><path class="cls-1" d="M19.14,2H4.86A2.86,2.86,0,0,0,2,4.86V19.14A2.86,2.86,0,0,0,4.86,22H19.14A2.86,2.86,0,0,0,22,19.14V4.86A2.86,2.86,0,0,0,19.14,2ZM4,4h6.22L4,10.22ZM4,18.71V13H4l9-9,0,0h5.71ZM5.54,20,20,5.54v5.69L11.23,20Zm8.52,0L20,14.06V20Z"/><path class="cls-1" d="M10.22,4H13L4,13V10.22ZM20,5.54V4H18.71L4,18.71V20H5.54ZM14.06,20,20,14.06V11.23L11.23,20Z"/></svg>
+<svg id="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <defs><style>.cls-1{fill:#000000;}</style></defs>
+  <title>icon - tool - measurement - area - line</title>
+  <path class="cls-1" d="M19.14,2H4.86A2.86,2.86,0,0,0,2,4.86V19.14A2.86,2.86,0,0,0,4.86,22H19.14A2.86,2.86,0,0,0,22,19.14V4.86A2.86,2.86,0,0,0,19.14,2ZM4,4h6.22L4,10.22ZM4,18.71V13H4l9-9,0,0h5.71ZM5.54,20,20,5.54v5.69L11.23,20Zm8.52,0L20,14.06V20Z"/><path class="cls-1" d="M10.22,4H13L4,13V10.22ZM20,5.54V4H18.71L4,18.71V20H5.54ZM14.06,20,20,14.06V11.23L11.23,20Z"/>
+</svg>

--- a/assets/icons/ic_annotation_rectangular_area_black_24px.svg
+++ b/assets/icons/ic_annotation_rectangular_area_black_24px.svg
@@ -1,4 +1,4 @@
-<svg id="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+<svg id="icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
   <defs><style>.cls-1{fill:#000000;}</style></defs>
   <title>icon - tool - measurement - area - line</title>
   <path class="cls-1" d="M19.14,2H4.86A2.86,2.86,0,0,0,2,4.86V19.14A2.86,2.86,0,0,0,4.86,22H19.14A2.86,2.86,0,0,0,22,19.14V4.86A2.86,2.86,0,0,0,19.14,2ZM4,4h6.22L4,10.22ZM4,18.71V13H4l9-9,0,0h5.71ZM5.54,20,20,5.54v5.69L11.23,20Zm8.52,0L20,14.06V20Z"/><path class="cls-1" d="M10.22,4H13L4,13V10.22ZM20,5.54V4H18.71L4,18.71V20H5.54ZM14.06,20,20,14.06V11.23L11.23,20Z"/>


### PR DESCRIPTION
Hello webviewer Maintainers,

I'm submitting this fix to ensure that the `assets/icons/ic_annotation_rectangular_area_black_24px.svg` file renders at the expected `width` and `height` of `24px`.

Here's what happens when you look at the `.svg` on `GitHub` on `Chrome`:

![image](https://user-images.githubusercontent.com/16601729/84822717-02038700-afd2-11ea-8295-23a42ce476cd.png)

I've also edited the formatting to improve readability.

# Screenshots

## Edge

### Before:

![image](https://user-images.githubusercontent.com/16601729/84822468-8f92a700-afd1-11ea-9056-17c8d9abe80f.png)

### After:

![image](https://user-images.githubusercontent.com/16601729/84822493-99b4a580-afd1-11ea-86fb-5fa61222e276.png)

## Chrome

### Before:

![image](https://user-images.githubusercontent.com/16601729/84822573-c4066300-afd1-11ea-9048-f85da6f02ef6.png)

### After:

![image](https://user-images.githubusercontent.com/16601729/84822604-cc5e9e00-afd1-11ea-8aec-920a0604890f.png)
