### PR TITLE
fix(a11y): remove prevent default in flyout menu

### DIFF
--- a/src/components/FlyoutMenu/FlyoutMenu.js
+++ b/src/components/FlyoutMenu/FlyoutMenu.js
@@ -90,9 +90,8 @@ function FlyoutMenu({ menu, trigger, onClose, children }) {
       const lastFocusedElement = document.activeElement;
 
       const keydownListener = e => {
-        // Tab closes the menu.
+        // Tab and Escape close the menu.
         if (e.key === 'Tab' || e.key === 'Escape') {
-          e.preventDefault();
           closeMenu();
           if (lastFocusedElement) {
             lastFocusedElement.focus();


### PR DESCRIPTION
leads to a more natural tabbing behavior by moving to the next element on tab (this is more accurate to native dropdown menu behavior as well)