### PR TITLE
Bug fix/ie 11 search bar

### DIFF
--- a/src/components/SearchOverlay/SearchOverlay.scss
+++ b/src/components/SearchOverlay/SearchOverlay.scss
@@ -17,7 +17,7 @@
   .input-container {
     display: flex;
     position: relative;
-    flex: 1 0 0;
+    flex: 1 0 auto;
 
     input {
       width: 100%;

--- a/src/components/SearchOverlay/SearchOverlay.scss
+++ b/src/components/SearchOverlay/SearchOverlay.scss
@@ -17,7 +17,7 @@
   .input-container {
     display: flex;
     position: relative;
-    flex: 1;
+    flex: 1 0 0;
 
     input {
       width: 100%;


### PR DESCRIPTION
Fixes: https://trello.com/c/bz3yw2IA/1064-ie11-new-ui-cant-type-in-search-panel
The problem:
So in plain words, if somewhere in your CSS you have something like this: flex:1 , that is not translated the same way in all browsers. Try changing it to 1 0 0 and I believe you will immediately see that it -kinda- works.

https://stackoverflow.com/questions/21600345/flexbox-and-internet-explorer-11-displayflex-in-html