### PR TITLE
Fixed issue with customPalette API

### DIFF
--- a/src/components/ColorPalette/ColorPalette.js
+++ b/src/components/ColorPalette/ColorPalette.js
@@ -14,7 +14,8 @@ class ColorPalette extends React.PureComponent {
     property: PropTypes.string.isRequired,
     color: PropTypes.object,
     onStyleChange: PropTypes.func.isRequired,
-    overridePalette: PropTypes.array,
+    overridePalette: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
+    colorMapKey: PropTypes.string
   }
 
   constructor(props) {
@@ -62,11 +63,19 @@ class ColorPalette extends React.PureComponent {
   }
 
   render() {
-    const { hasPadding, style = {}, property, color, overridePalette, overridePalette2 } = this.props;
+    const {
+      hasPadding,
+      style = {},
+      property,
+      color,
+      overridePalette,
+      overridePalette2,
+      colorMapKey
+    } = this.props;
 
     const allowTransparent = !(property === 'TextColor' || property === 'StrokeColor');
 
-    const palette = overridePalette2 || overridePalette || this.palette;
+    const palette = overridePalette2 ||  overridePalette?.[colorMapKey] || overridePalette?.global || this.palette;
 
     return (
       <div


### PR DESCRIPTION
Fixes https://trello.com/c/nTY5SgpH/1008-new-ui-calling-instancesetcolorpalette-will-blow-the-app-up

However, when users customize the pallete for a specific tool, the new UI will still show the default colors 
![image](https://user-images.githubusercontent.com/10825527/85910618-c8eac400-b7d4-11ea-9c0e-e2fc59a2f7a1.png)


Do we want to keep this API or how should we approach this?
@khein-pdftron 