### PR TITLE
When notes panel disabled

### DIFF
--- a/src/components/Accessibility/Accessibility.js
+++ b/src/components/Accessibility/Accessibility.js
@@ -9,6 +9,7 @@ import './Accessibility.scss';
 class Accessibility extends React.PureComponent {
   static propTypes = {
     isAccessibleMode: PropTypes.bool,
+    isNotesPanelDisabled: PropTypes.bool,
   }
 
   state = {
@@ -24,13 +25,14 @@ class Accessibility extends React.PureComponent {
   }
 
   render() {
-    const { isAccessibleMode } = this.props;
+    const { isAccessibleMode, isNotesPanelDisabled } = this.props;
     const { isVisible } = this.state;
 
     if (!isAccessibleMode) {
       return null;
     }
 
+    const skiptoNotes = isNotesPanelDisabled ? null : <div className="skip-to-notes" onFocus={this.onFocus} onBlur={this.onBlur} tabIndex={0}>Notes</div>;
     const className = `Accessibility ${isVisible ? 'visible' : 'hidden'}`;
 
     return (
@@ -38,7 +40,7 @@ class Accessibility extends React.PureComponent {
         <div>Skip to: </div>
         <input className="skip-to-hack" tabIndex={-1}></input>
         <div className="skip-to-document" onFocus={this.onFocus} onBlur={this.onBlur} tabIndex={0}>Document</div>
-        <div className="skip-to-notes" onFocus={this.onFocus} onBlur={this.onBlur} tabIndex={0}>Notes</div>
+        {skiptoNotes}
       </div>
     );
   }
@@ -46,6 +48,7 @@ class Accessibility extends React.PureComponent {
 
 const mapStateToProps = state => ({
   isAccessibleMode: selectors.isAccessibleMode(state),
+  isNotesPanelDisabled: selectors.isElementDisabled(state, 'notesPanel')
 });
 
 export default connect(mapStateToProps)(Accessibility);


### PR DESCRIPTION
dont show in accessibility header

Fixes:
https://support.pdftron.com/a/tickets/14757

If WV is in accessibility mode, when the notes panel is disabled, a skip to notes link is still shown to the user. This removes that link if the notes panel is disabled
![image](https://user-images.githubusercontent.com/10825527/86180541-37839680-bae1-11ea-852f-32cbf9080719.png)
