### PR TITLE
feat: add data-elements to some controls in the bookmark panel

### DIFF
--- a/src/components/Bookmark/Bookmark.js
+++ b/src/components/Bookmark/Bookmark.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 
 import EditingBookmark from 'components/Bookmark/EditingBookmark';
 import Icon from 'components/Icon';
+import Element from 'components/Element';
 
 import actions from 'actions';
 
@@ -60,7 +61,7 @@ class Bookmark extends React.PureComponent {
           {text}
         </div>
         {this.state.isHovered &&
-          <div className="bookmark-controls bookmark-button">
+          <Element dataElement="bookmarkControls" className="bookmark-controls bookmark-button">
             <div
               onClick={() => this.setState({ isEditing: true })}
             >
@@ -75,7 +76,7 @@ class Bookmark extends React.PureComponent {
                 glyph="cancel-24px"
               />
             </div>
-          </div>
+          </Element>
         }
       </div>
     );

--- a/src/components/BookmarksPanel/BookmarksPanel.js
+++ b/src/components/BookmarksPanel/BookmarksPanel.js
@@ -5,7 +5,7 @@ import { withTranslation } from 'react-i18next';
 
 import Bookmark from 'components/Bookmark';
 import EditingBookmark from 'components/Bookmark/EditingBookmark';
-import Icon from 'components/Icon';
+import Button from 'components/Button';
 
 import actions from 'actions';
 import selectors from 'selectors';
@@ -63,14 +63,14 @@ class BookmarksPanel extends React.PureComponent {
               }}
             /> :
             <div className="bookmarks-panel-header ">
-              <div
+              <Button
+                dataElement="newBookmarkButton"
                 className="bookmarks-panel-button"
+                label={t('component.newBookmark')}
                 onClick={() => {
                   this.setState({ isAdding: true });
                 }}
-              >
-                {t('component.newBookmark')}
-              </div>
+              />
             </div>
         }
         <div className="bookmarks-panel-row">


### PR DESCRIPTION
This PR is to address the feedback from https://support.pdftron.com/a/tickets/14897

Two new `data-element`s have been added to the bookmark panel, so the client can call `instance.disableElements` to hide them.