### PR TITLE
Update to dangerouslySetNoteTransform example

### DIFF
--- a/src/apis/setNoteTransformFunction.js
+++ b/src/apis/setNoteTransformFunction.js
@@ -43,7 +43,7 @@ Webviewer(...)
   .then(instance => {
     instance.dangerouslySetNoteTransformFunction((wrapper, state, createElement) => {
       // Change the title of every note
-      wrapper.querySelector('.title>span').innerHTML = 'My custom note title';
+      wrapper.querySelector('.author-and-time>span').innerHTML = 'My custom note title';
 
       // Add a button that alerts the user when clicked
       const button = createElement('button');


### PR DESCRIPTION
Small update to the example for `dangerouslySetNoteTransformFunction`

The classes used in the note changed with the new UI, so the example used doesn't work anymore and blows up the app.
https://trello.com/c/pRSHYkF5

As a side note - the changing of classes will break the app for anyone still relying on those for querySelectors. How will we communicate this?