### PR TITLE
[Bugfix] Fixed warning modal staying open after loading another document

### DIFF
--- a/src/components/WarningModal/WarningModal.js
+++ b/src/components/WarningModal/WarningModal.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import i18next from 'i18next';
+import core from 'core';
 
 import Button from 'components/Button';
 
@@ -29,12 +30,20 @@ class WarningModal extends React.PureComponent {
     onCancel: PropTypes.func,
   };
 
+  componentDidMount() {
+    core.addEventListener('documentUnloaded', this.onCancel);
+  }
+
   componentDidUpdate(prevProps) {
     const { isOpen, closeElements } = this.props;
 
     // if (!prevProps.isOpen && isOpen) {
     //   closeElements(getPopupElements());
     // }
+  }
+
+  componentWillUnmount() {
+    core.removeEventListener('documentUnloaded', this.onCancel);
   }
 
   onCancel = () => {


### PR DESCRIPTION
If you attempt to delete a page, a warning modal will appear. Without closing the modal or selecting an option, load another document, and the modal will remain. Choosing to delete the page will delete the page on the new document.

This PR will fix this issue by closing the modal on `documentUnloaded`.