### PR TITLE
Uncommenting elements closing event dispatch on document unloading and d changing SearchOverlay to SearchPanel since searchOverlay is no longer a DOM element

### DIFF
--- a/src/event-listeners/onDocumentUnloaded.js
+++ b/src/event-listeners/onDocumentUnloaded.js
@@ -1,7 +1,7 @@
 import actions from 'actions';
 
 export default dispatch => () => {
-  // dispatch(actions.closeElements(['pageNavOverlay', 'searchOverlay', 'leftPanel']));
+  dispatch(actions.closeElements(['pageNavOverlay', 'searchPanel', 'leftPanel']));
   dispatch(actions.setOutlines([]));
   dispatch(actions.setTotalPages(0));
 };


### PR DESCRIPTION
To test:
1. Load a document
2. Click search button
3. Search for some term
4. Observe the search result on the search panel
5. Load another document
6. Observe the search panel being closed
7. Open search panel
8. Observe no search results