### PR TITLE
[Fix] decrease swipe threshold to make swipe more responsive

### DIFF
--- a/src/helpers/TouchEventManager.js
+++ b/src/helpers/TouchEventManager.js
@@ -200,7 +200,7 @@ const TouchEventManager = {
         }
 
         const { reachedLeft, reachedTop, reachedRight, reachedBottom } = this.reachedBoundary();
-        const threshold = 0.35 * this.container.clientWidth;
+        const threshold = 0.1 * this.container.clientWidth;
         const swipedToBottom = reachedBottom && this.touch.verticalDistance > threshold;
         const swipedToTop = reachedTop && this.touch.verticalDistance < -threshold;
         const swipedToRight = reachedRight && this.touch.horizontalDistance > threshold;


### PR DESCRIPTION
Changed swipe threshold to 0.1 of page width from 0.35, which seems to most optimal value for user experience.

See:
https://trello.com/c/oOaKumTk/1108-on-continuous-page-mode-swipe-left-and-right-not-registered-always-ios-1351

