### PR TITLE
Used tReady prop to not render component until translation file has b…

### DIFF
--- a/src/components/Ribbons/Ribbons.js
+++ b/src/components/Ribbons/Ribbons.js
@@ -12,7 +12,7 @@ import Measure from 'react-measure';
 import "./Ribbons.scss";
 
 const Ribbons = ({ toolbarGroups, currentToolbarGroup, setToolbarGroup }) => {
-  const [t] = useTranslation();
+  const { t, ready } = useTranslation();
   const [ribbonsWidth, setRibbonsWidth] = useState(0);
   const [containerWidth, setContainerWidth] = useState(0);
   const [hasEnoughSpace, setHasEnoughSpace] = useState(false);
@@ -31,8 +31,9 @@ const Ribbons = ({ toolbarGroups, currentToolbarGroup, setToolbarGroup }) => {
       }
     }
   }, [ribbonsWidth, containerWidth, ribbonsRef, containerRef]);
-
-  if (toolbarGroups.length <= 1) {
+  // if translation file is not loaded, don't render component
+  // else it will show untranslated text
+  if (toolbarGroups.length <= 1 || !ready ) {
     return null;
   }
 

--- a/src/components/ToolsOverlay/ToolsOverlay.js
+++ b/src/components/ToolsOverlay/ToolsOverlay.js
@@ -109,6 +109,7 @@ class ToolsOverlay extends React.PureComponent {
   render() {
     const {
       t,
+      tReady,
       isDisabled,
       isOpen,
       toolNames,
@@ -119,7 +120,8 @@ class ToolsOverlay extends React.PureComponent {
     } = this.props;
 
     const isVisible = (isOpen || true) && !isDisabled;
-    if (!isVisible) {
+    // if translation file is not ready, don't render else it looks weird and bad to see untranslated text
+    if (!isVisible || !tReady) {
       return null;
     }
 


### PR DESCRIPTION
Fixes https://trello.com/c/uSOD1bd6/1166-untranslated-text-in-header-before-the-translations-are-loaded

To replicate:
Load the UI, you will see some untranslated text in the header.
Its for a brief moment.

Solution:
Made use of 
https://react.i18next.com/legacy-v9/step-by-step-guide#c-handle-rendering-while-translations-are-not-yet-loaded
https://react.i18next.com/latest/usetranslation-hook#not-using-suspense

So that component doesn't appear until translation file has been loaded