### PR TITLE
Changed i18next XHR backend to HTTP

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "hotkeys-js": "^3.7.3",
     "html2canvas": "git+https://github.com/mparizeau/html2canvas.git",
     "i18next": "^19.0.3",
-    "i18next-xhr-backend": "^3.2.2",
+    "i18next-http-backend": "^1.0.16",
     "node-sass": "^4.13.1",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",

--- a/src/helpers/setupI18n.js
+++ b/src/helpers/setupI18n.js
@@ -1,5 +1,5 @@
 import i18next from 'i18next';
-import XHR from 'i18next-xhr-backend';
+import HttpApi from 'i18next-http-backend';
 
 export default state => {
   const options = {
@@ -26,7 +26,7 @@ export default state => {
   if (state.advanced.disableI18n) {
     i18next.init(options, callback);
   } else {
-    i18next.use(XHR).init(
+    i18next.use(HttpApi).init(
       {
         ...options,
         backend: {


### PR DESCRIPTION
i18next-xhr-backend is now deprecated. i18next-http-backend is now the recommended replacement.

The usage and API is similar but for our use case, they should be exactly the same.