### PR TITLE
Fixed scrollTo not working in IE11

### DIFF
--- a/src/components/HeaderItems/ToolGroupButtonsScroll.js
+++ b/src/components/HeaderItems/ToolGroupButtonsScroll.js
@@ -65,7 +65,9 @@ const ToolGroupButtonsScroll = ({ toolGroupButtonsItems }) => {
                 )}
                 onClick={() => {
                   // Move two tools over
-                  scrollRef.current.scrollTo(scrollRef.current.scrollLeft - 54 * 2, 0);
+                  // don't use scrollTo as it doesn't work in IE11
+                  scrollRef.current.scrollTop = (0);
+                  scrollRef.current.scrollLeft = (scrollRef.current.scrollLeft - 54 * 2);
                 }}
               >
                 <Icon  glyph="icon-chevron-left" />
@@ -84,7 +86,9 @@ const ToolGroupButtonsScroll = ({ toolGroupButtonsItems }) => {
                 )}
                 onClick={() => {
                   // Move two tools over
-                  scrollRef.current.scrollTo(scrollRef.current.scrollLeft + 54 * 2, 0);
+                  // don't use scrollTo as it doesn't work in IE11
+                  scrollRef.current.scrollTop = (0);
+                  scrollRef.current.scrollLeft = (scrollRef.current.scrollLeft + 54 * 2);
                 }}
               >
                 <Icon  glyph="icon-chevron-right" />

--- a/src/components/HeaderItems/ToolGroupButtonsScroll.js
+++ b/src/components/HeaderItems/ToolGroupButtonsScroll.js
@@ -66,8 +66,8 @@ const ToolGroupButtonsScroll = ({ toolGroupButtonsItems }) => {
                 onClick={() => {
                   // Move two tools over
                   // don't use scrollTo as it doesn't work in IE11
-                  scrollRef.current.scrollTop = (0);
-                  scrollRef.current.scrollLeft = (scrollRef.current.scrollLeft - 54 * 2);
+                  scrollRef.current.scrollTop = 0;
+                  scrollRef.current.scrollLeft = scrollRef.current.scrollLeft - 54 * 2;
                 }}
               >
                 <Icon  glyph="icon-chevron-left" />
@@ -87,8 +87,8 @@ const ToolGroupButtonsScroll = ({ toolGroupButtonsItems }) => {
                 onClick={() => {
                   // Move two tools over
                   // don't use scrollTo as it doesn't work in IE11
-                  scrollRef.current.scrollTop = (0);
-                  scrollRef.current.scrollLeft = (scrollRef.current.scrollLeft + 54 * 2);
+                  scrollRef.current.scrollTop = 0;
+                  scrollRef.current.scrollLeft = scrollRef.current.scrollLeft + 54 * 2;
                 }}
               >
                 <Icon  glyph="icon-chevron-right" />


### PR DESCRIPTION
https://trello.com/c/85cmruGj/1162-button-to-scroll-tools-to-the-right-or-left-doesnt-work-in-ie-or-old-edge

SO link that helped me:
https://stackoverflow.com/questions/51517324/scrollto-method-doesnt-work-in-edge