### PR TITLE
[Bugfix] Fix issue with overlapping comments

### DIFF
--- a/src/components/NotesPanel/VirtualizedList/VirtualizedList.js
+++ b/src/components/NotesPanel/VirtualizedList/VirtualizedList.js
@@ -30,6 +30,11 @@ const VirtualizedList = React.forwardRef(
       listRef.current.scrollToPosition(initialScrollTop);
     }, [initialScrollTop]);
 
+    useEffect(() => {
+      cache.clearAll();
+      listRef?.current?.recomputeRowHeights();
+    }, [notes.length]);
+
     const _resize = index => {
       cache.clear(index);
       listRef.current?.recomputeRowHeights(index);


### PR DESCRIPTION
When adding new annotations (mainly text ones like highlight, underline, etc)  the following happens (this affect 7.0 and 6.X)

![image](https://user-images.githubusercontent.com/45575633/87699057-27a6bc00-c749-11ea-8442-94e66c872117.png)

The issue is when we have a lot of comments (more than the NotesPanel.js `VIRTUALIZATION_THRESHOLD` of 100), and start adding more, we use the `VirtualizedLIst.js` component that is buggy. The issue seem to be it's not recalculating the height of notes so the overlapping happens.

My fix is to recalculate height when new notes are added