### PR TITLE
Fix issue where the annotation layer that overlaps the thumbnail doesn't quite line up

### DIFF
--- a/src/components/Thumbnail/Thumbnail.scss
+++ b/src/components/Thumbnail/Thumbnail.scss
@@ -33,7 +33,7 @@
       box-shadow: 0px 0px 3px 0px var(--box-shadow);
     }
 
-    .annotation-image {
+    .annotation-image, .page-image {
       position: absolute;
       left: 50%;
       top: 50%;


### PR DESCRIPTION
This was because the positioning on the page and annotation layers didn't quite match up
The annotation layer was absolutely positioned and the page wasn't.
This change just gives them the same CSS styles so they overlap exactly.

To verify load a PDF and add a rectangle over the middle of some text. Check the thumbnail and previously you would see the rectangle is slightly shifted down compared to where it should be. Now they should match much more closely. 

It can be easier to tell if you use the browser zoom to zoom in.