### PR TITLE
Rotation buttons shouldn't be displayed in the thumbnail panel when loading with WVS

### DIFF
--- a/src/components/ThumbnailControls/ThumbnailControls.js
+++ b/src/components/ThumbnailControls/ThumbnailControls.js
@@ -60,23 +60,33 @@ const ThumbnailControls = ({
     dispatch(actions.showWarningMessage(warning));
   };
 
+  const isWVSDocument = core.getDocument().isWebViewerServerDocument();
+
   return isElementDisabled ? null : (
     <div className="thumbnailControls" data-element={dataElementName}>
-      <Button
-        img="icon-header-page-manipulation-page-rotation-counterclockwise-line"
-        onClick={rotateCounterClockwise}
-        title="option.thumbnailPanel.rotateCounterClockwise"
-      />
+      {
+        !isWVSDocument && (
+          <Button
+            img="icon-header-page-manipulation-page-rotation-counterclockwise-line"
+            onClick={rotateCounterClockwise}
+            title="option.thumbnailPanel.rotateCounterClockwise"
+          />
+        )
+      }
       <Button
         img="icon-delete-line"
         onClick={handleDelete}
         title="option.thumbnailPanel.delete"
       />
-      <Button
-        img="icon-header-page-manipulation-page-rotation-clockwise-line"
-        onClick={rotateClockwise}
-        title="option.thumbnailPanel.rotateClockwise"
-      />
+      {
+        !isWVSDocument && (
+          <Button
+            img="icon-header-page-manipulation-page-rotation-clockwise-line"
+            onClick={rotateClockwise}
+            title="option.thumbnailPanel.rotateClockwise"
+          />
+        )
+      }
     </div>
   );
 };

--- a/src/components/ThumbnailControls/ThumbnailControls.js
+++ b/src/components/ThumbnailControls/ThumbnailControls.js
@@ -9,7 +9,6 @@ import selectors from 'selectors';
 import actions from 'actions';
 
 import './ThumbnailControls.scss';
-import { workerTypes } from "constants/types";
 
 const propTypes = {
   index: PropTypes.number.isRequired,
@@ -20,7 +19,7 @@ const dataElementName = 'thumbnailControl';
 const ThumbnailControls = ({
   index,
 }) => {
-  let [isElementDisabled] = useSelector(state => [
+  const [isElementDisabled] = useSelector(state => [
     selectors.isElementDisabled(state, dataElementName),
   ]);
 
@@ -61,28 +60,33 @@ const ThumbnailControls = ({
     dispatch(actions.showWarningMessage(warning));
   };
 
-  if (!isElementDisabled) {
-    const docType = core.getDocument().getType();
-    isElementDisabled = !(docType === workerTypes.PDF || (docType === workerTypes.BLACKBOX && !core.isWebViewerServerDocument()));
-  }
+  const isWVSDocument = core.getDocument().isWebViewerServerDocument();
 
   return isElementDisabled ? null : (
     <div className="thumbnailControls" data-element={dataElementName}>
-      <Button
-        img="icon-header-page-manipulation-page-rotation-counterclockwise-line"
-        onClick={rotateCounterClockwise}
-        title="option.thumbnailPanel.rotateCounterClockwise"
-      />
+      {
+        !isWVSDocument && (
+          <Button
+            img="icon-header-page-manipulation-page-rotation-counterclockwise-line"
+            onClick={rotateCounterClockwise}
+            title="option.thumbnailPanel.rotateCounterClockwise"
+          />
+        )
+      }
       <Button
         img="icon-delete-line"
         onClick={handleDelete}
         title="option.thumbnailPanel.delete"
       />
-      <Button
-        img="icon-header-page-manipulation-page-rotation-clockwise-line"
-        onClick={rotateClockwise}
-        title="option.thumbnailPanel.rotateClockwise"
-      />
+      {
+        !isWVSDocument && (
+          <Button
+            img="icon-header-page-manipulation-page-rotation-clockwise-line"
+            onClick={rotateClockwise}
+            title="option.thumbnailPanel.rotateClockwise"
+          />
+        )
+      }
     </div>
   );
 };

--- a/src/components/ThumbnailControls/ThumbnailControls.js
+++ b/src/components/ThumbnailControls/ThumbnailControls.js
@@ -9,6 +9,7 @@ import selectors from 'selectors';
 import actions from 'actions';
 
 import './ThumbnailControls.scss';
+import { workerTypes } from "constants/types";
 
 const propTypes = {
   index: PropTypes.number.isRequired,
@@ -19,7 +20,7 @@ const dataElementName = 'thumbnailControl';
 const ThumbnailControls = ({
   index,
 }) => {
-  const [isElementDisabled] = useSelector(state => [
+  let [isElementDisabled] = useSelector(state => [
     selectors.isElementDisabled(state, dataElementName),
   ]);
 
@@ -60,33 +61,28 @@ const ThumbnailControls = ({
     dispatch(actions.showWarningMessage(warning));
   };
 
-  const isWVSDocument = core.getDocument().isWebViewerServerDocument();
+  if (!isElementDisabled) {
+    const docType = core.getDocument().getType();
+    isElementDisabled = !(docType === workerTypes.PDF || (docType === workerTypes.BLACKBOX && !core.isWebViewerServerDocument()));
+  }
 
   return isElementDisabled ? null : (
     <div className="thumbnailControls" data-element={dataElementName}>
-      {
-        !isWVSDocument && (
-          <Button
-            img="icon-header-page-manipulation-page-rotation-counterclockwise-line"
-            onClick={rotateCounterClockwise}
-            title="option.thumbnailPanel.rotateCounterClockwise"
-          />
-        )
-      }
+      <Button
+        img="icon-header-page-manipulation-page-rotation-counterclockwise-line"
+        onClick={rotateCounterClockwise}
+        title="option.thumbnailPanel.rotateCounterClockwise"
+      />
       <Button
         img="icon-delete-line"
         onClick={handleDelete}
         title="option.thumbnailPanel.delete"
       />
-      {
-        !isWVSDocument && (
-          <Button
-            img="icon-header-page-manipulation-page-rotation-clockwise-line"
-            onClick={rotateClockwise}
-            title="option.thumbnailPanel.rotateClockwise"
-          />
-        )
-      }
+      <Button
+        img="icon-header-page-manipulation-page-rotation-clockwise-line"
+        onClick={rotateClockwise}
+        title="option.thumbnailPanel.rotateClockwise"
+      />
     </div>
   );
 };

--- a/src/components/ThumbnailControls/ThumbnailControls.js
+++ b/src/components/ThumbnailControls/ThumbnailControls.js
@@ -60,33 +60,23 @@ const ThumbnailControls = ({
     dispatch(actions.showWarningMessage(warning));
   };
 
-  const isWVSDocument = core.getDocument().isWebViewerServerDocument();
-
   return isElementDisabled ? null : (
     <div className="thumbnailControls" data-element={dataElementName}>
-      {
-        !isWVSDocument && (
-          <Button
-            img="icon-header-page-manipulation-page-rotation-counterclockwise-line"
-            onClick={rotateCounterClockwise}
-            title="option.thumbnailPanel.rotateCounterClockwise"
-          />
-        )
-      }
+      <Button
+        img="icon-header-page-manipulation-page-rotation-counterclockwise-line"
+        onClick={rotateCounterClockwise}
+        title="option.thumbnailPanel.rotateCounterClockwise"
+      />
       <Button
         img="icon-delete-line"
         onClick={handleDelete}
         title="option.thumbnailPanel.delete"
       />
-      {
-        !isWVSDocument && (
-          <Button
-            img="icon-header-page-manipulation-page-rotation-clockwise-line"
-            onClick={rotateClockwise}
-            title="option.thumbnailPanel.rotateClockwise"
-          />
-        )
-      }
+      <Button
+        img="icon-header-page-manipulation-page-rotation-clockwise-line"
+        onClick={rotateClockwise}
+        title="option.thumbnailPanel.rotateClockwise"
+      />
     </div>
   );
 };

--- a/src/components/ThumbnailsPanel/ThumbnailsPanel.js
+++ b/src/components/ThumbnailsPanel/ThumbnailsPanel.js
@@ -69,7 +69,7 @@ class ThumbnailsPanel extends React.PureComponent {
     core.addEventListener('annotationHidden', this.onAnnotationChanged);
 
     // The document might have already been loaded before this component is mounted.
-    // If document is already loaded, call 'onDocumentLoaded()' manually.
+    // If document is already loaded, call 'onDocumentLoaded()' manually to update the state properly.
     if (core.getDocument()) {
       this.onDocumentLoaded();
     }

--- a/src/components/ThumbnailsPanel/ThumbnailsPanel.js
+++ b/src/components/ThumbnailsPanel/ThumbnailsPanel.js
@@ -68,6 +68,7 @@ class ThumbnailsPanel extends React.PureComponent {
     core.addEventListener('pageComplete', this.onPageComplete);
     core.addEventListener('annotationHidden', this.onAnnotationChanged);
 
+    // The document might have already been loaded before this component is mounted.
     // If document is already loaded, call 'onDocumentLoaded()' manually.
     if (core.getDocument()) {
       this.onDocumentLoaded();

--- a/src/components/ThumbnailsPanel/ThumbnailsPanel.js
+++ b/src/components/ThumbnailsPanel/ThumbnailsPanel.js
@@ -68,7 +68,7 @@ class ThumbnailsPanel extends React.PureComponent {
     core.addEventListener('pageComplete', this.onPageComplete);
     core.addEventListener('annotationHidden', this.onAnnotationChanged);
 
-    // If document is alraedy loaded, call 'onDocumentLoaded()' manually.
+    // If document is already loaded, call 'onDocumentLoaded()' manually.
     if (core.getDocument()) {
       this.onDocumentLoaded();
     }

--- a/src/components/ThumbnailsPanel/ThumbnailsPanel.js
+++ b/src/components/ThumbnailsPanel/ThumbnailsPanel.js
@@ -67,6 +67,11 @@ class ThumbnailsPanel extends React.PureComponent {
     core.addEventListener('pageNumberUpdated', this.onPageNumberUpdated);
     core.addEventListener('pageComplete', this.onPageComplete);
     core.addEventListener('annotationHidden', this.onAnnotationChanged);
+
+    // If document is alraedy loaded, call 'onDocumentLoaded()' manually.
+    if (core.getDocument()) {
+      this.onDocumentLoaded();
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
- Calling "this.onDocumentLoaded()" manually if document is already loaded.


https://trello.com/c/H15Wx2wX/1176-rotation-buttons-shouldnt-be-displayed-in-the-thumbnail-panel-when-loading-with-wvs

![image](https://user-images.githubusercontent.com/66745183/87835778-edb9e080-c842-11ea-8243-9a5bb427d010.png)

