### PR TITLE
[Bugfix] Update UI to use the updated Print API

### DIFF
--- a/src/apis/print.js
+++ b/src/apis/print.js
@@ -16,6 +16,8 @@ WebViewer(...)
 import print from 'helpers/print';
 import selectors from 'selectors';
 
-export default store => () => {
-  print(store.dispatch, selectors.isEmbedPrintSupported(store.getState()));
+export default store => {
+  window.docViewer.getAnnotationManager().getFieldManager().setPrintHandler(() => {
+    print(store.dispatch, selectors.isEmbedPrintSupported(store.getState()));
+  });
 };

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ import setupLoadAnnotationsFromServer from 'helpers/setupLoadAnnotationsFromServ
 import eventHandler from 'helpers/eventHandler';
 import setupI18n from 'helpers/setupI18n';
 import setAutoSwitch from 'helpers/setAutoSwitch';
+import setPrintHandler from './apis/print';
 import setDefaultDisabledElements from 'helpers/setDefaultDisabledElements';
 import setupDocViewer from 'helpers/setupDocViewer';
 import setDefaultToolStyles from 'helpers/setDefaultToolStyles';
@@ -147,6 +148,7 @@ if (window.CanvasRenderingContext2D) {
     setupI18n(state);
     setUserPermission(state);
     setAutoSwitch();
+    setPrintHandler(store);
     addEventHandlers();
     setDefaultDisabledElements(store);
     setupLoadAnnotationsFromServer(store);


### PR DESCRIPTION
In core, I made a change to replace jQuery print function. 
In this PR [merge to master], I update UI to connect with the `print` function defined inside getAnnotationManager
Once the Core PR get merge in, we can test using a file "Test for Print API.pdf" for testing.

