### PR TITLE
[Bugfix] [legacy/master] Update UI to use the updated Print API 

### DIFF
--- a/src/apis/print.js
+++ b/src/apis/print.js
@@ -16,6 +16,8 @@ WebViewer(...)
 import print from 'helpers/print';
 import selectors from 'selectors';
 
-export default store => () => {
-  print(store.dispatch, selectors.isEmbedPrintSupported(store.getState()));
+export default store => {
+  window.docViewer.getAnnotationManager().getFieldManager().setPrintHandler(() => {
+    print(store.dispatch, selectors.isEmbedPrintSupported(store.getState()));
+  });
 };

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ import setAutoSwitch from 'helpers/setAutoSwitch';
 import setDefaultDisabledElements from 'helpers/setDefaultDisabledElements';
 import setupDocViewer from 'helpers/setupDocViewer';
 import setDefaultToolStyles from 'helpers/setDefaultToolStyles';
+import setPrintHandler from './apis/print';
 import setUserPermission from 'helpers/setUserPermission';
 import logDebugInfo from 'helpers/logDebugInfo';
 import rootReducer from 'reducers/rootReducer';
@@ -83,7 +84,7 @@ if (window.CanvasRenderingContext2D) {
       if (workerTransportPromise.pdf || workerTransportPromise.office) {
         window.CoreControls.setWorkerTransportPromise(workerTransportPromise);
       } else {
-        window.CoreControls.setWorkerTransportPromise({ 'pdf': workerTransportPromise });
+        window.CoreControls.setWorkerTransportPromise({ pdf: workerTransportPromise });
       }
     }
   } catch (e) {
@@ -98,64 +99,74 @@ if (window.CanvasRenderingContext2D) {
   function initTransports() {
     const { PDF, OFFICE, ALL } = workerTypes;
     if (preloadWorker === PDF || preloadWorker === ALL) {
-      getBackendPromise(getHashParams('pdf', 'auto')).then(pdfType => {
-        window.CoreControls.initPDFWorkerTransports(pdfType, {
-          workerLoadingProgress: percent => {
-            store.dispatch(actions.setLoadingProgress(percent));
+      getBackendPromise(getHashParams('pdf', 'auto')).then((pdfType) => {
+        window.CoreControls.initPDFWorkerTransports(
+          pdfType,
+          {
+            workerLoadingProgress: (percent) => {
+              store.dispatch(actions.setLoadingProgress(percent));
+            },
           },
-        }, window.sampleL);
+          window.sampleL
+        );
       });
     }
 
     if (preloadWorker === OFFICE || preloadWorker === ALL) {
-      getBackendPromise(getHashParams('office', 'auto')).then(officeType => {
-        window.CoreControls.initOfficeWorkerTransports(officeType, {
-          workerLoadingProgress: percent => {
-            store.dispatch(actions.setLoadingProgress(percent));
+      getBackendPromise(getHashParams('office', 'auto')).then((officeType) => {
+        window.CoreControls.initOfficeWorkerTransports(
+          officeType,
+          {
+            workerLoadingProgress: (percent) => {
+              store.dispatch(actions.setLoadingProgress(percent));
+            },
           },
-        }, window.sampleL);
+          window.sampleL
+        );
       });
     }
   }
-
 
   loadCustomCSS(state.advanced.customCSS);
 
   logDebugInfo();
 
-  fullAPIReady.then(() => loadConfig()).then(() => {
-    if (preloadWorker) {
-      initTransports();
-    }
+  fullAPIReady
+    .then(() => loadConfig())
+    .then(() => {
+      if (preloadWorker) {
+        initTransports();
+      }
 
-    const { addEventHandlers, removeEventHandlers } = eventHandler(store);
-    const docViewer = new window.CoreControls.DocumentViewer();
+      const { addEventHandlers, removeEventHandlers } = eventHandler(store);
+      const docViewer = new window.CoreControls.DocumentViewer();
 
-    window.docViewer = docViewer;
-    if (getHashParams('enableViewStateAnnotations', false)) {
-      const tool = docViewer.getTool(window.Tools.ToolNames.STICKY);
-      tool?.setSaveViewState(true);
-    }
+      window.docViewer = docViewer;
+      if (getHashParams('enableViewStateAnnotations', false)) {
+        const tool = docViewer.getTool(window.Tools.ToolNames.STICKY);
+        tool?.setSaveViewState(true);
+      }
 
-    setupDocViewer();
-    setupI18n(state);
-    setUserPermission(state);
-    setAutoSwitch();
-    addEventHandlers();
-    setDefaultDisabledElements(store);
-    setupLoadAnnotationsFromServer(store);
-    setDefaultToolStyles();
-    core.setToolMode(defaultTool);
+      setupDocViewer();
+      setupI18n(state);
+      setUserPermission(state);
+      setAutoSwitch();
+      addEventHandlers();
+      setDefaultDisabledElements(store);
+      setupLoadAnnotationsFromServer(store);
+      setDefaultToolStyles();
+      core.setToolMode(defaultTool);
+      setPrintHandler(store);
 
-    ReactDOM.render(
-      <Provider store={store}>
-        <I18nextProvider i18n={i18next}>
-          <App removeEventHandlers={removeEventHandlers} />
-        </I18nextProvider>
-      </Provider>,
-      document.getElementById('app'),
-    );
-  });
+      ReactDOM.render(
+        <Provider store={store}>
+          <I18nextProvider i18n={i18next}>
+            <App removeEventHandlers={removeEventHandlers} />
+          </I18nextProvider>
+        </Provider>,
+        document.getElementById('app')
+      );
+    });
 }
 
 window.addEventListener('hashchange', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -84,7 +84,7 @@ if (window.CanvasRenderingContext2D) {
       if (workerTransportPromise.pdf || workerTransportPromise.office) {
         window.CoreControls.setWorkerTransportPromise(workerTransportPromise);
       } else {
-        window.CoreControls.setWorkerTransportPromise({ pdf: workerTransportPromise });
+        window.CoreControls.setWorkerTransportPromise({ 'pdf': workerTransportPromise });
       }
     }
   } catch (e) {
@@ -99,74 +99,65 @@ if (window.CanvasRenderingContext2D) {
   function initTransports() {
     const { PDF, OFFICE, ALL } = workerTypes;
     if (preloadWorker === PDF || preloadWorker === ALL) {
-      getBackendPromise(getHashParams('pdf', 'auto')).then((pdfType) => {
-        window.CoreControls.initPDFWorkerTransports(
-          pdfType,
-          {
-            workerLoadingProgress: (percent) => {
-              store.dispatch(actions.setLoadingProgress(percent));
-            },
+      getBackendPromise(getHashParams('pdf', 'auto')).then(pdfType => {
+        window.CoreControls.initPDFWorkerTransports(pdfType, {
+          workerLoadingProgress: percent => {
+            store.dispatch(actions.setLoadingProgress(percent));
           },
-          window.sampleL
-        );
+        }, window.sampleL);
       });
     }
 
     if (preloadWorker === OFFICE || preloadWorker === ALL) {
-      getBackendPromise(getHashParams('office', 'auto')).then((officeType) => {
-        window.CoreControls.initOfficeWorkerTransports(
-          officeType,
-          {
-            workerLoadingProgress: (percent) => {
-              store.dispatch(actions.setLoadingProgress(percent));
-            },
+      getBackendPromise(getHashParams('office', 'auto')).then(officeType => {
+        window.CoreControls.initOfficeWorkerTransports(officeType, {
+          workerLoadingProgress: percent => {
+            store.dispatch(actions.setLoadingProgress(percent));
           },
-          window.sampleL
-        );
+        }, window.sampleL);
       });
     }
   }
+
 
   loadCustomCSS(state.advanced.customCSS);
 
   logDebugInfo();
 
-  fullAPIReady
-    .then(() => loadConfig())
-    .then(() => {
-      if (preloadWorker) {
-        initTransports();
-      }
+  fullAPIReady.then(() => loadConfig()).then(() => {
+    if (preloadWorker) {
+      initTransports();
+    }
 
-      const { addEventHandlers, removeEventHandlers } = eventHandler(store);
-      const docViewer = new window.CoreControls.DocumentViewer();
+    const { addEventHandlers, removeEventHandlers } = eventHandler(store);
+    const docViewer = new window.CoreControls.DocumentViewer();
 
-      window.docViewer = docViewer;
-      if (getHashParams('enableViewStateAnnotations', false)) {
-        const tool = docViewer.getTool(window.Tools.ToolNames.STICKY);
-        tool?.setSaveViewState(true);
-      }
+    window.docViewer = docViewer;
+    if (getHashParams('enableViewStateAnnotations', false)) {
+      const tool = docViewer.getTool(window.Tools.ToolNames.STICKY);
+      tool?.setSaveViewState(true);
+    }
 
-      setupDocViewer();
-      setupI18n(state);
-      setUserPermission(state);
-      setAutoSwitch();
-      addEventHandlers();
-      setDefaultDisabledElements(store);
-      setupLoadAnnotationsFromServer(store);
-      setDefaultToolStyles();
-      core.setToolMode(defaultTool);
-      setPrintHandler(store);
+    setupDocViewer();
+    setupI18n(state);
+    setUserPermission(state);
+    setAutoSwitch();
+    addEventHandlers();
+    setDefaultDisabledElements(store);
+    setupLoadAnnotationsFromServer(store);
+    setDefaultToolStyles();
+    core.setToolMode(defaultTool);
+    setPrintHandler(store);
 
-      ReactDOM.render(
-        <Provider store={store}>
-          <I18nextProvider i18n={i18next}>
-            <App removeEventHandlers={removeEventHandlers} />
-          </I18nextProvider>
-        </Provider>,
-        document.getElementById('app')
-      );
-    });
+    ReactDOM.render(
+      <Provider store={store}>
+        <I18nextProvider i18n={i18next}>
+          <App removeEventHandlers={removeEventHandlers} />
+        </I18nextProvider>
+      </Provider>,
+      document.getElementById('app'),
+    );
+  });
 }
 
 window.addEventListener('hashchange', () => {


### PR DESCRIPTION
In core, I made a change to replace jQuery print function. 
In this PR [merge to legacy/master], I update UI to connect with the `print` function defined inside getAnnotationManager
Once the Core PR get merge in, we can test using a file "Test for Print API.pdf" for testing.