### PR TITLE
[Bugfix] [merge to legacy/7.0] Update UI to use the updated Print API

### DIFF
--- a/src/apis/print.js
+++ b/src/apis/print.js
@@ -16,6 +16,8 @@ WebViewer(...)
 import print from 'helpers/print';
 import selectors from 'selectors';
 
-export default store => () => {
-  print(store.dispatch, selectors.isEmbedPrintSupported(store.getState()));
+export default store => {
+  window.docViewer.getAnnotationManager().getFieldManager().setPrintHandler(() => {
+    print(store.dispatch, selectors.isEmbedPrintSupported(store.getState()));
+  });
 };

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ import setDefaultDisabledElements from 'helpers/setDefaultDisabledElements';
 import setupDocViewer from 'helpers/setupDocViewer';
 import setDefaultToolStyles from 'helpers/setDefaultToolStyles';
 import setUserPermission from 'helpers/setUserPermission';
+import setPrintHandler from './apis/print';
 import logDebugInfo from 'helpers/logDebugInfo';
 import rootReducer from 'reducers/rootReducer';
 import getHashParams from 'helpers/getHashParams';
@@ -146,6 +147,7 @@ if (window.CanvasRenderingContext2D) {
     setupLoadAnnotationsFromServer(store);
     setDefaultToolStyles();
     core.setToolMode(defaultTool);
+    setPrintHandler(store);
 
     ReactDOM.render(
       <Provider store={store}>


### PR DESCRIPTION
In core, I made a change to replace jQuery print function. 
In this PR [merge to legacy/7.0], I update UI to connect with the `print` function defined inside getAnnotationManager
Once the Core PR get merge in, we can test using a file "Test for Print API.pdf" for testing.