### PR TITLE
[Bugfix] Fixed issue where user could not immediately edit free text in IE11

### DIFF
--- a/src/components/AnnotationPopup/AnnotationPopup.js
+++ b/src/components/AnnotationPopup/AnnotationPopup.js
@@ -11,7 +11,7 @@ import core from 'core';
 import { getAnnotationPopupPositionBasedOn } from 'helpers/getPopupPosition';
 import getAnnotationStyles from 'helpers/getAnnotationStyles';
 import applyRedactions from 'helpers/applyRedactions';
-import { isMobile } from 'helpers/device';
+import { isMobile, isIE } from 'helpers/device';
 import useOnClickOutside from 'hooks/useOnClickOutside';
 import actions from 'actions';
 import selectors from 'selectors';
@@ -327,7 +327,7 @@ const AnnotationPopup = () => {
   </div>;
 
   return (
-    isMobile() ?
+    isIE || isMobile() ?
     annotationPopup
     :
     <Draggable cancel=".Button, .cell, .sliders-container svg">


### PR DESCRIPTION
When editing a free text or callout annotation in IE11, the text cursor will appear but not allow you to enter text until you click on the location you want to edit or select text. The culprit is the `react-draggable` component around the `AnnotationPopup` component. The reason is unclear (IE11 doesn't like something it does?).

This PR corrects the issue by removing draggable when using IE since it works in 'real' browsers.

![freetext](https://user-images.githubusercontent.com/25498512/88093274-a1261c00-cb46-11ea-8d61-5606175a7717.gif)
