### PR TITLE
[Bugfix] Fixed buttons being cut off in IE11

### DIFF
--- a/src/components/Bookmark/EditingBookmark.scss
+++ b/src/components/Bookmark/EditingBookmark.scss
@@ -26,6 +26,7 @@
     align-items: center;
     color: var(--primary-button-text);
     padding: 6px 18px;
+    width: auto;
     width: fit-content;
     background: var(--primary-button);
     border-radius: 4px;

--- a/src/components/BookmarksPanel/BookmarksPanel.scss
+++ b/src/components/BookmarksPanel/BookmarksPanel.scss
@@ -24,6 +24,7 @@
       align-items: center;
       color: var(--primary-button-text);
       padding: 6px 18px;
+      width: auto;
       width: fit-content;
       background: var(--primary-button);
       border-radius: 4px;

--- a/src/components/CalibrationModal/CalibrationModal.scss
+++ b/src/components/CalibrationModal/CalibrationModal.scss
@@ -114,6 +114,7 @@
         padding: 6px 18px;
         margin-top: 8px;
         margin-left: 5px;
+        width: auto;
         width: fit-content;
         background: var(--primary-button);
         border-radius: 4px;

--- a/src/components/LinkModal/LinkModal.scss
+++ b/src/components/LinkModal/LinkModal.scss
@@ -174,6 +174,7 @@
       padding: 6px 18px;
       margin-top: 8px;
       margin-left: 5px;
+      width: auto;
       width: fit-content;
       background: var(--primary-button);
       border-radius: 4px;

--- a/src/components/PrintModal/PrintModal.scss
+++ b/src/components/PrintModal/PrintModal.scss
@@ -122,6 +122,7 @@
         align-items: center;
         color: var(--primary-button-text);
         padding: 6px 18px;
+        width: auto;
         width: fit-content;
         background: var(--primary-button);
         border-radius: 4px;

--- a/src/components/PrintModal/WatermarkModal/WatermarkModal.scss
+++ b/src/components/PrintModal/WatermarkModal/WatermarkModal.scss
@@ -179,6 +179,7 @@
       justify-content: center;
       align-items: center;
       padding: 6px 18px;
+      width: auto;
       width: fit-content;
       border-radius: 4px;
       border: 0px;

--- a/src/constants/modal.scss
+++ b/src/constants/modal.scss
@@ -30,6 +30,7 @@ $modal-z-index: 100;
       align-items: center;
       padding: 6px 18px;
       margin-top: 8px;
+      width: auto;
       width: fit-content;
       border-radius: 4px;
       height: 30px;


### PR DESCRIPTION
Fixed issue with buttons being cut off in IE11 since `fit-content` was not supported. This PR uses the solution proposed by @khein-pdftron which seems to work.