### PR TITLE
[Bugfix] Fixed touch errors coming up in IE11 when creating measurement annots

### DIFF
--- a/src/components/MeasurementOverlay/MeasurementOverlay.js
+++ b/src/components/MeasurementOverlay/MeasurementOverlay.js
@@ -109,7 +109,7 @@ class MeasurementOverlay extends React.PureComponent {
   isMouseInsideRect = (e, overlayElement) => {
     const overlayRect = overlayElement.getBoundingClientRect();
     let x,y;
-    if (e instanceof TouchEvent && e.touches) {
+    if (e.touches && e instanceof TouchEvent) {
       x = e.touches[0].clientX;
       y = e.touches[0].clientY;
     } else {


### PR DESCRIPTION
The issue occurs when checks were performed using the `TouchEvent` type which doesn't exist in IE11. This PR swaps the check to check for the `touches` property first before the type.