### PR TITLE
Moved out logic from PrintModal to Print Helper

### DIFF
--- a/src/apis/print.js
+++ b/src/apis/print.js
@@ -13,7 +13,7 @@ WebViewer(...)
   });
  */
 
-import print from 'helpers/print';
+import { print } from 'helpers/print';
 import selectors from 'selectors';
 
 export default store => () => {

--- a/src/components/MenuOverlay/MenuOverlay.js
+++ b/src/components/MenuOverlay/MenuOverlay.js
@@ -6,7 +6,7 @@ import core from 'core';
 import { isIOS } from 'helpers/device';
 import downloadPdf from 'helpers/downloadPdf';
 import openFilePicker from 'helpers/openFilePicker';
-import print from 'helpers/print';
+import { print } from 'helpers/print';
 import toggleFullscreen from 'helpers/toggleFullscreen';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/components/PrintModal/PrintModal.js
+++ b/src/components/PrintModal/PrintModal.js
@@ -2,20 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withTranslation } from 'react-i18next';
-import dayjs from 'dayjs';
 
-import Input from 'components/Input';
 import WatermarkModal from 'components/PrintModal/WatermarkModal';
 
 import core from 'core';
 import getPageArrayFromString from 'helpers/getPageArrayFromString';
 import getClassName from 'helpers/getClassName';
-import { getSortStrategies } from 'constants/sortStrategies';
-import { mapAnnotationToKey, getDataWithKey } from 'constants/map';
+import { creatingPages, printPages, cancelPrint } from 'helpers/print';
 import LayoutMode from 'constants/layoutMode';
 import actions from 'actions';
 import selectors from 'selectors';
-import { isSafari, isChromeOniOS } from 'helpers/device';
 
 import { Swipeable } from 'react-swipeable';
 
@@ -55,7 +51,8 @@ class PrintModal extends React.PureComponent {
       isWatermarkModalVisible: false,
       watermarkModalOption: null,
       existingWatermarks: null,
-      includeAnnotations: true
+      includeAnnotations: true,
+      includeComments: false,
     };
   }
 
@@ -156,10 +153,12 @@ class PrintModal extends React.PureComponent {
       core.setWatermark(this.state.existingWatermarks);
     }
 
-    const creatingPages = this.creatingPages();
-    Promise.all(creatingPages)
+    const createPages = creatingPages(this.state.pagesToPrint, this.state.includeComments, this.state.includeAnnotations, this.props.printQuality, this.props.sortStrategy, this.props.colorMap);
+    Promise.all(createPages)
       .then(pages => {
-        this.printPages(pages);
+        debugger;
+        printPages(pages);
+        this.closePrintModal();
       })
       .catch(e => {
         console.error(e);
@@ -167,297 +166,9 @@ class PrintModal extends React.PureComponent {
       });
   };
 
-  creatingPages = () => {
-    const creatingPages = [];
-
-    this.pendingCanvases = [];
-    this.state.pagesToPrint.forEach(pageNumber => {
-      const printableAnnotations = this.getPrintableAnnotations(pageNumber);
-      creatingPages.push(this.creatingImage(pageNumber, printableAnnotations));
-
-      if (this.includeComments.current.checked && printableAnnotations.length) {
-        const sortedNotes = getSortStrategies()[
-          this.props.sortStrategy
-        ].getSortedNotes(printableAnnotations);
-        creatingPages.push(this.creatingNotesPage(sortedNotes, pageNumber));
-      }
-    });
-
-    return creatingPages;
-  };
-
-  creatingImage = (pageNumber, printableAnnotations) =>
-    new Promise(resolve => {
-      const pageIndex = pageNumber - 1;
-      const zoom = 1;
-      const printRotation = this.getPrintRotation(pageIndex);
-      const onCanvasLoaded = async canvas => {
-        this.pendingCanvases = this.pendingCanvases.filter(
-          pendingCanvas => pendingCanvas !== id,
-        );
-        this.positionCanvas(canvas, pageIndex);
-
-        if (this.state.includeAnnotations) {
-          await this.drawAnnotationsOnCanvas(canvas, pageNumber);
-        } else {
-          // disable all printable annotations before draw
-          printableAnnotations.forEach(annot => annot.Printable = false);
-          await this.drawAnnotationsOnCanvas(canvas, pageNumber);
-          // enable all printable annotations after draw
-          printableAnnotations.forEach(annot => annot.Printable = true);
-        }
-
-        const img = document.createElement('img');
-        img.src = canvas.toDataURL();
-        img.onload = () => {
-          this.setState(({ count }) => ({
-            count: count < 0 ? -1 : count + 1,
-          }));
-          resolve(img);
-        };
-      };
-      const id = core.getDocument().loadCanvasAsync({
-        pageNumber,
-        zoom,
-        pageRotation: printRotation,
-        drawComplete: onCanvasLoaded,
-        multiplier: this.props.printQuality,
-      });
-      this.pendingCanvases.push(id);
-    });
-
-  getPrintRotation = pageIndex => {
-    const { width, height } = core.getPageInfo(pageIndex + 1);
-    const documentRotation = this.getDocumentRotation(pageIndex);
-    let printRotation = (4 - documentRotation) % 4;
-
-    // automatically rotate pages so that they fill up as much of the printed page as possible
-    if (printRotation % 2 === 0 && width > height) {
-      printRotation++;
-    } else if (printRotation % 2 === 1 && height > width) {
-      printRotation--;
-    }
-
-    return printRotation;
-  };
-
-  positionCanvas = (canvas, pageIndex) => {
-    const { width, height } = core.getPageInfo(pageIndex + 1);
-    const documentRotation = this.getDocumentRotation(pageIndex);
-    const ctx = canvas.getContext('2d');
-
-    switch (documentRotation) {
-      case 1:
-        ctx.translate(width, 0);
-        break;
-      case 2:
-        ctx.translate(width, height);
-        break;
-      case 3:
-        ctx.translate(0, height);
-        break;
-    }
-
-    ctx.rotate((documentRotation * 90 * Math.PI) / 180);
-  };
-
-  getDocumentRotation = pageIndex => {
-    const pageNumber = pageIndex + 1;
-    const completeRotation = core.getCompleteRotation(pageNumber);
-    const viewerRotation = core.getRotation(pageNumber);
-
-    return (completeRotation - viewerRotation + 4) % 4;
-  };
-
-  drawAnnotationsOnCanvas = (canvas, pageNumber) => {
-    const widgetAnnotations = core
-      .getAnnotationsList()
-      .filter(
-        annot =>
-          annot.PageNumber === pageNumber && annot instanceof window.Annotations.WidgetAnnotation
-      );
-    // just draw markup annotations
-    if (widgetAnnotations.length === 0) {
-      return core.drawAnnotations(pageNumber, canvas);
-    }
-    // draw all annotations
-    const widgetContainer = this.createWidgetContainer(pageNumber - 1);
-    return core.drawAnnotations(pageNumber, canvas, true, widgetContainer).then(() => {
-      document.body.appendChild(widgetContainer);
-
-      return import(/* webpackChunkName: 'html2canvas' */ 'html2canvas').then(
-        ({ default: html2canvas }) => {
-          return html2canvas(widgetContainer, {
-            canvas,
-            backgroundColor: null,
-            scale: 1,
-            logging: false,
-          }).then(() => {
-            document.body.removeChild(widgetContainer);
-          });
-        }
-      );
-    });
-  };
-
-  createWidgetContainer = pageIndex => {
-    const { width, height } = core.getPageInfo(pageIndex + 1);
-    const widgetContainer = document.createElement('div');
-
-    widgetContainer.id = 'printWidgetContainer';
-    widgetContainer.style.width = width;
-    widgetContainer.style.height = height;
-    widgetContainer.style.position = 'relative';
-    widgetContainer.style.top = '-10000px';
-
-    return widgetContainer;
-  };
-
-  getPrintableAnnotations = pageNumber =>
-    core
-      .getAnnotationsList()
-      .filter(
-        annotation =>
-          annotation.Listable &&
-          annotation.PageNumber === pageNumber &&
-          !annotation.isReply() &&
-          !annotation.isGrouped() &&
-          annotation.Printable,
-      );
-
-  creatingNotesPage = (annotations, pageNumber) =>
-    new Promise(resolve => {
-      const container = document.createElement('div');
-      container.className = 'page__container';
-
-      const header = document.createElement('div');
-      header.className = 'page__header';
-      header.innerHTML = `Page ${pageNumber}`;
-
-      container.appendChild(header);
-      annotations.forEach(annotation => {
-        const note = this.getNote(annotation);
-
-        container.appendChild(note);
-      });
-
-      resolve(container);
-    });
-
-  getNote = annotation => {
-    const note = document.createElement('div');
-    note.className = 'note';
-
-    const noteRoot = document.createElement('div');
-    noteRoot.className = 'note__root';
-
-    const noteRootInfo = document.createElement('div');
-    noteRootInfo.className = 'note__info--with-icon';
-
-    const noteIcon = this.getNoteIcon(annotation);
-
-    noteRootInfo.appendChild(noteIcon);
-    noteRootInfo.appendChild(this.getNoteInfo(annotation));
-    noteRoot.appendChild(noteRootInfo);
-    noteRoot.appendChild(this.getNoteContent(annotation));
-
-    note.appendChild(noteRoot);
-    annotation.getReplies().forEach(reply => {
-      const noteReply = document.createElement('div');
-      noteReply.className = 'note__reply';
-      noteReply.appendChild(this.getNoteInfo(reply));
-      noteReply.appendChild(this.getNoteContent(reply));
-
-      note.appendChild(noteReply);
-    });
-
-    return note;
-  };
-
-  getNoteIcon = annotation => {
-    const { colorMap } = this.props;
-    const key = mapAnnotationToKey(annotation);
-    const iconColor = colorMap[key] && colorMap[key].iconColor;
-    const icon = getDataWithKey(key).icon;
-    const isBase64 = icon && icon.trim().indexOf('data:') === 0;
-
-    let noteIcon;
-    if (isBase64) {
-      noteIcon = document.createElement('img');
-      noteIcon.src = icon;
-    } else {
-      let innerHTML;
-      if (icon) {
-        const isInlineSvg = icon.indexOf('<svg') === 0;
-        /* eslint-disable global-require */
-        innerHTML = isInlineSvg ? icon : require(`../../../assets/icons/${icon}.svg`);
-      } else {
-        innerHTML = annotation.Subject;
-      }
-
-      noteIcon = document.createElement('div');
-      noteIcon.innerHTML = innerHTML;
-    }
-
-    noteIcon.className = 'note__icon';
-    noteIcon.style.color = iconColor && annotation[iconColor].toHexString();
-    return noteIcon;
-  };
-
-  getNoteInfo = annotation => {
-    const info = document.createElement('div');
-
-    info.className = 'note__info';
-    info.innerHTML = `
-      Author: ${core.getDisplayAuthor(annotation) || ''} &nbsp;&nbsp;
-      Subject: ${annotation.Subject} &nbsp;&nbsp;
-      Date: ${dayjs(annotation.DateCreated).format('D/MM/YYYY h:mm:ss A')}
-    `;
-    return info;
-  };
-
-  getNoteContent = annotation => {
-    const contentElement = document.createElement('div');
-    const contentText = annotation.getContents();
-
-    contentElement.className = 'note__content';
-    if (contentText) {
-      // ensure that new lines are preserved and rendered properly
-      contentElement.style.whiteSpace = 'pre-wrap';
-      contentElement.innerHTML = `${contentText}`;
-    }
-    return contentElement;
-  };
-
-  printPages = pages => {
-    const printHandler = document.getElementById('print-handler');
-    printHandler.innerHTML = '';
-
-    const fragment = document.createDocumentFragment();
-    pages.forEach(page => {
-      fragment.appendChild(page);
-    });
-
-    printHandler.appendChild(fragment);
-
-    if (isSafari && !isChromeOniOS) {
-      // Print for Safari browser. Makes Safari 11 consistently work.
-      document.execCommand('print');
-    } else {
-      window.print();
-    }
-    this.closePrintModal();
-  };
-
   closePrintModal = () => {
     this.setState({ count: -1 });
     this.props.closeElement('printModal');
-  };
-
-  cancelPrint = () => {
-    const doc = core.getDocument();
-    this.pendingCanvases.forEach(id => doc.cancelLoadCanvas(id));
-    this.setState({ count: -1 });
   };
 
   setWatermarkModalVisibility = visible => {
@@ -514,7 +225,7 @@ class PrintModal extends React.PureComponent {
               className={className}
               data-element="printModal"
               onClick={() => {
-                this.cancelPrint();
+                cancelPrint();
                 this.closePrintModal();
               }}
             >
@@ -564,6 +275,7 @@ class PrintModal extends React.PureComponent {
                       id="include-comments"
                       name="comments"
                       label={t('option.print.includeComments')}
+                      onChange = {() => this.setState(state => ({ includeComments: !state.includeComments }))}
                       disabled={isPrinting}
                       center
                     />

--- a/src/components/PrintModal/PrintModal.js
+++ b/src/components/PrintModal/PrintModal.js
@@ -153,7 +153,16 @@ class PrintModal extends React.PureComponent {
       core.setWatermark(this.state.existingWatermarks);
     }
 
-    const createPages = creatingPages(this.state.pagesToPrint, this.state.includeComments, this.state.includeAnnotations, this.props.printQuality, this.props.sortStrategy, this.props.colorMap);
+    const createPages = creatingPages(this.state.pagesToPrint,
+      this.state.includeComments,
+      this.state.includeAnnotations,
+      this.props.printQuality,
+      this.props.sortStrategy,
+      this.props.colorMap);
+    createPages.forEach(async pagePromise => {
+      await pagePromise;
+      this.setState({ count: this.state.count < this.state.pagesToPrint.length ? this.state.count+1 : this.state.count });
+    });
     Promise.all(createPages)
       .then(pages => {
         printPages(pages);

--- a/src/components/PrintModal/PrintModal.js
+++ b/src/components/PrintModal/PrintModal.js
@@ -156,7 +156,6 @@ class PrintModal extends React.PureComponent {
     const createPages = creatingPages(this.state.pagesToPrint, this.state.includeComments, this.state.includeAnnotations, this.props.printQuality, this.props.sortStrategy, this.props.colorMap);
     Promise.all(createPages)
       .then(pages => {
-        debugger;
         printPages(pages);
         this.closePrintModal();
       })

--- a/src/helpers/hotkeysManager.js
+++ b/src/helpers/hotkeysManager.js
@@ -6,7 +6,7 @@ import openFilePicker from 'helpers/openFilePicker';
 import copyText from 'helpers/copyText';
 import setToolModeAndGroup from 'helpers/setToolModeAndGroup';
 import { zoomIn, zoomOut } from 'helpers/zoom';
-import print from 'helpers/print';
+import { print } from 'helpers/print';
 import createTextAnnotationAndSelect from 'helpers/createTextAnnotationAndSelect';
 import { isMobile } from 'helpers/device';
 import isFocusingElement from 'helpers/isFocusingElement';

--- a/src/helpers/print.js
+++ b/src/helpers/print.js
@@ -1,10 +1,20 @@
 import i18n from 'i18next';
 
 import actions from 'actions';
+import dayjs from 'dayjs';
 import { workerTypes } from 'constants/types';
+import { getSortStrategies } from 'constants/sortStrategies';
+import { mapAnnotationToKey, getDataWithKey } from 'constants/map';
+import { isSafari, isChromeOniOS } from 'helpers/device';
 import core from 'core';
 
-export default (dispatch, isEmbedPrintSupported) => {
+let pendingCanvases = [];
+let includeAnnotations = false;
+let printQuality = 1;
+let count = -1;
+let colorMap;
+
+export const print = (dispatch, isEmbedPrintSupported) => {
   if (!core.getDocument()) {
     return;
   }
@@ -53,3 +63,284 @@ const printPdf = () =>
         });
       });
   });
+
+export const creatingPages = (pagesToPrint, includeComments, includeAnnot, printQualty, sortStrategy, clrMap) => {
+  const createdPages = [];
+  pendingCanvases = [];
+  includeAnnotations = includeAnnot;
+  printQuality = printQualty;
+  colorMap = clrMap;
+
+  pagesToPrint.forEach(pageNumber => {
+    const printableAnnotations = getPrintableAnnotations(pageNumber);
+    createdPages.push(creatingImage(pageNumber, printableAnnotations));
+
+    if (includeComments && printableAnnotations.length) {
+      const sortedNotes = getSortStrategies()[sortStrategy].getSortedNotes(printableAnnotations);
+      createdPages.push(creatingNotesPage(sortedNotes, pageNumber));
+    }
+  });
+
+  return createdPages;
+};
+
+export const printPages = pages => {
+  const printHandler = document.getElementById('print-handler');
+  printHandler.innerHTML = '';
+
+  const fragment = document.createDocumentFragment();
+  pages.forEach(page => {
+    fragment.appendChild(page);
+  });
+
+  printHandler.appendChild(fragment);
+
+  if (isSafari && !isChromeOniOS) {
+    // Print for Safari browser. Makes Safari 11 consistently work.
+    document.execCommand('print');
+  } else {
+    window.print();
+  }
+};
+
+export const cancelPrint = () => {
+  const doc = core.getDocument();
+  pendingCanvases.forEach(id => doc.cancelLoadCanvas(id));
+  count = -1;
+};
+
+
+const getPrintableAnnotations = pageNumber =>
+  core
+    .getAnnotationsList()
+    .filter(
+      annotation =>
+        annotation.Listable &&
+        annotation.PageNumber === pageNumber &&
+        !annotation.isReply() &&
+        !annotation.isGrouped() &&
+        annotation.Printable,
+    );
+
+const creatingImage = (pageNumber, printableAnnotations) =>
+  new Promise(resolve => {
+    const pageIndex = pageNumber - 1;
+    const zoom = 1;
+    const printRotation = getPrintRotation(pageIndex);
+    const onCanvasLoaded = async canvas => {
+      pendingCanvases = pendingCanvases.filter(pendingCanvas => pendingCanvas !== id);
+      positionCanvas(canvas, pageIndex);
+
+      if (includeAnnotations) {
+        await drawAnnotationsOnCanvas(canvas, pageNumber);
+      } else {
+        // disable all printable annotations before draw
+        printableAnnotations.forEach(annot => (annot.Printable = false));
+        await drawAnnotationsOnCanvas(canvas, pageNumber);
+        // enable all printable annotations after draw
+        printableAnnotations.forEach(annot => (annot.Printable = true));
+      }
+
+      const img = document.createElement('img');
+      img.src = canvas.toDataURL();
+      img.onload = () => {
+        count = count < 0 ? -1 : count + 1;
+        resolve(img);
+      };
+    };
+    const id = core.getDocument().loadCanvasAsync({
+      pageNumber,
+      zoom,
+      pageRotation: printRotation,
+      drawComplete: onCanvasLoaded,
+      multiplier: printQuality,
+    });
+    pendingCanvases.push(id);
+  });
+
+const creatingNotesPage = (annotations, pageNumber) =>
+  new Promise(resolve => {
+    const container = document.createElement('div');
+    container.className = 'page__container';
+
+    const header = document.createElement('div');
+    header.className = 'page__header';
+    header.innerHTML = `Page ${pageNumber}`;
+
+    container.appendChild(header);
+    annotations.forEach(annotation => {
+      const note = getNote(annotation);
+
+      container.appendChild(note);
+    });
+
+    resolve(container);
+  });
+
+const getPrintRotation = pageIndex => {
+  const { width, height } = core.getPageInfo(pageIndex + 1);
+  const documentRotation = getDocumentRotation(pageIndex);
+  let printRotation = (4 - documentRotation) % 4;
+
+  // automatically rotate pages so that they fill up as much of the printed page as possible
+  if (printRotation % 2 === 0 && width > height) {
+    printRotation++;
+  } else if (printRotation % 2 === 1 && height > width) {
+    printRotation--;
+  }
+
+  return printRotation;
+};
+
+const positionCanvas = (canvas, pageIndex) => {
+  const { width, height } = core.getPageInfo(pageIndex + 1);
+  const documentRotation = getDocumentRotation(pageIndex);
+  const ctx = canvas.getContext('2d');
+
+  switch (documentRotation) {
+    case 1:
+      ctx.translate(width, 0);
+      break;
+    case 2:
+      ctx.translate(width, height);
+      break;
+    case 3:
+      ctx.translate(0, height);
+      break;
+  }
+
+  ctx.rotate((documentRotation * 90 * Math.PI) / 180);
+};
+
+const drawAnnotationsOnCanvas = (canvas, pageNumber) => {
+  const widgetAnnotations = core
+    .getAnnotationsList()
+    .filter(annot => annot.PageNumber === pageNumber && annot instanceof window.Annotations.WidgetAnnotation);
+  // just draw markup annotations
+  if (widgetAnnotations.length === 0) {
+    return core.drawAnnotations(pageNumber, canvas);
+  }
+  // draw all annotations
+  const widgetContainer = createWidgetContainer(pageNumber - 1);
+  return core.drawAnnotations(pageNumber, canvas, true, widgetContainer).then(() => {
+    document.body.appendChild(widgetContainer);
+
+    return import(/* webpackChunkName: 'html2canvas' */ 'html2canvas').then(({ default: html2canvas }) => {
+      return html2canvas(widgetContainer, {
+        canvas,
+        backgroundColor: null,
+        scale: 1,
+        logging: false,
+      }).then(() => {
+        document.body.removeChild(widgetContainer);
+      });
+    });
+  });
+};
+
+const getDocumentRotation = pageIndex => {
+  const pageNumber = pageIndex + 1;
+  const completeRotation = core.getCompleteRotation(pageNumber);
+  const viewerRotation = core.getRotation(pageNumber);
+
+  return (completeRotation - viewerRotation + 4) % 4;
+};
+
+
+const getNote = annotation => {
+  const note = document.createElement('div');
+  note.className = 'note';
+
+  const noteRoot = document.createElement('div');
+  noteRoot.className = 'note__root';
+
+  const noteRootInfo = document.createElement('div');
+  noteRootInfo.className = 'note__info--with-icon';
+
+  const noteIcon = getNoteIcon(annotation);
+
+  noteRootInfo.appendChild(noteIcon);
+  noteRootInfo.appendChild(getNoteInfo(annotation));
+  noteRoot.appendChild(noteRootInfo);
+  noteRoot.appendChild(getNoteContent(annotation));
+
+  note.appendChild(noteRoot);
+  annotation.getReplies().forEach(reply => {
+    const noteReply = document.createElement('div');
+    noteReply.className = 'note__reply';
+    noteReply.appendChild(getNoteInfo(reply));
+    noteReply.appendChild(getNoteContent(reply));
+
+    note.appendChild(noteReply);
+  });
+
+  return note;
+};
+
+const getNoteIcon = annotation => {
+  const key = mapAnnotationToKey(annotation);
+  const iconColor = colorMap[key] && colorMap[key].iconColor;
+  const icon = getDataWithKey(key).icon;
+  const isBase64 = icon && icon.trim().indexOf('data:') === 0;
+
+  let noteIcon;
+  if (isBase64) {
+    noteIcon = document.createElement('img');
+    noteIcon.src = icon;
+  } else {
+    let innerHTML;
+    if (icon) {
+      const isInlineSvg = icon.indexOf('<svg') === 0;
+      /* eslint-disable global-require */
+      innerHTML = isInlineSvg ? icon : require(`../../assets/icons/${icon}.svg`);
+    } else {
+      innerHTML = annotation.Subject;
+    }
+
+    noteIcon = document.createElement('div');
+    noteIcon.innerHTML = innerHTML;
+  }
+
+  noteIcon.className = 'note__icon';
+  noteIcon.style.color = iconColor && annotation[iconColor].toHexString();
+  return noteIcon;
+};
+
+const getNoteInfo = annotation => {
+  const info = document.createElement('div');
+
+  info.className = 'note__info';
+  info.innerHTML = `
+    Author: ${core.getDisplayAuthor(annotation) || ''} &nbsp;&nbsp;
+    Subject: ${annotation.Subject} &nbsp;&nbsp;
+    Date: ${dayjs(annotation.DateCreated).format('D/MM/YYYY h:mm:ss A')}
+  `;
+  return info;
+};
+
+const getNoteContent = annotation => {
+  const contentElement = document.createElement('div');
+  const contentText = annotation.getContents();
+
+  contentElement.className = 'note__content';
+  if (contentText) {
+    // ensure that new lines are preserved and rendered properly
+    contentElement.style.whiteSpace = 'pre-wrap';
+    contentElement.innerHTML = `${contentText}`;
+  }
+  return contentElement;
+};
+
+const createWidgetContainer = pageIndex => {
+  const { width, height } = core.getPageInfo(pageIndex + 1);
+  const widgetContainer = document.createElement('div');
+
+  widgetContainer.id = 'printWidgetContainer';
+  widgetContainer.style.width = width;
+  widgetContainer.style.height = height;
+  widgetContainer.style.position = 'relative';
+  widgetContainer.style.top = '-10000px';
+
+  return widgetContainer;
+};
+

--- a/src/helpers/print.js
+++ b/src/helpers/print.js
@@ -11,7 +11,6 @@ import core from 'core';
 let pendingCanvases = [];
 let includeAnnotations = false;
 let printQuality = 1;
-let count = -1;
 let colorMap;
 
 export const print = (dispatch, isEmbedPrintSupported) => {
@@ -106,7 +105,6 @@ export const printPages = pages => {
 export const cancelPrint = () => {
   const doc = core.getDocument();
   pendingCanvases.forEach(id => doc.cancelLoadCanvas(id));
-  count = -1;
 };
 
 
@@ -144,7 +142,6 @@ const creatingImage = (pageNumber, printableAnnotations) =>
       const img = document.createElement('img');
       img.src = canvas.toDataURL();
       img.onload = () => {
-        count = count < 0 ? -1 : count + 1;
         resolve(img);
       };
     };


### PR DESCRIPTION
PrintModal should have logic only for rendering the component, so made sense to move it out of PrintModal and into PrintHelper. 

Testing it on dev freezes Chrome due to react/chrome issue:
facebook/react: Issue #17155
facebook/react: Issue #16734

So to test it out, build the UI and place it in WebViewer 7.0.

Ran through all combinations and ensured nothing broke.