### PR TITLE
Refactor link modal to improve the performance of documents with many pages

### DIFF
--- a/src/components/LinkModal/LinkModal.js
+++ b/src/components/LinkModal/LinkModal.js
@@ -180,18 +180,6 @@ const LinkModal = () => {
     }
   }, [tabSelected, isOpen, pageNumberInput, urlInput]);
 
-  const setDropdownNumbers = () => {
-    const numbers = [];
-    for (let i = 1; i <= totalPages; i++) {
-      numbers.push(
-        <option key={i} value={i}>
-          {i}
-        </option>
-      );
-    }
-    return numbers;
-  };
-
   const modalClass = classNames({
     Modal: true,
     LinkModal: true,
@@ -240,18 +228,19 @@ const LinkModal = () => {
           <TabPanel dataElement="PageNumberPanel">
             <form onSubmit={addPageLink}>
               <div>{t('link.enterpage')}</div>
-              <select
-                className="pageNumberSelect"
+              <input
+                type="number"
                 ref={pageNumberInput}
                 value={pageNumber}
-                onChange={e => setPageNumber(e.target.value)}
-              >
-                {setDropdownNumbers()}
-              </select>
+                onChange={e => setPageNumber(parseInt(e.target.value, 10))}
+                min={1}
+                max={totalPages}
+              />
               <Button
                 dataElement="linkSubmitButton"
                 label={t('action.link')}
                 onClick={addPageLink}
+                disable={pageNumber < 0 || pageNumber > totalPages}
               />
             </form>
           </TabPanel>

--- a/src/components/LinkModal/LinkModal.js
+++ b/src/components/LinkModal/LinkModal.js
@@ -240,7 +240,7 @@ const LinkModal = () => {
                 dataElement="linkSubmitButton"
                 label={t('action.link')}
                 onClick={addPageLink}
-                disable={pageNumber < 0 || pageNumber > totalPages}
+                disable={pageNumber < 1 || pageNumber > totalPages}
               />
             </form>
           </TabPanel>

--- a/src/components/LinkModal/LinkModal.scss
+++ b/src/components/LinkModal/LinkModal.scss
@@ -105,6 +105,12 @@
           background: #17324c;
           border: 1px solid #17324c;
         }
+
+        &.disable {
+          background: $gray20;
+          border-color: $gray20;
+          cursor: not-allowed;
+        }
       }
     }
   }


### PR DESCRIPTION
The link modal creates a dropdown with an option for every page number
so for large documents (thousands of pages) this can take quite a while
to render.

This change updates the behavior so that you can type the page number
instead and the link button is disabled if the page is out of bounds.