### PR TITLE
Refactor link modal to improve the performance of documents with many pages

### DIFF
--- a/src/components/LinkModal/LinkModal.js
+++ b/src/components/LinkModal/LinkModal.js
@@ -195,18 +195,6 @@ const LinkModal = () => {
     }
   }, [tabSelected, isOpen, pageNumberInput, urlInput]);
 
-  const setDropdownNumbers = () => {
-    const numbers = [];
-    for (let i = 1; i <= totalPages; i++) {
-      numbers.push(
-        <option key={i} value={i}>
-          {i}
-        </option>
-      );
-    }
-    return numbers;
-  };
-
   const modalClass = classNames({
     Modal: true,
     LinkModal: true,
@@ -261,18 +249,19 @@ const LinkModal = () => {
               <form onSubmit={addPageLink}>
                 <div>{t('link.enterpage')}</div>
                 <div className="linkInput">
-                  <select
-                    className="pageNumberSelect"
+                  <input
+                    type="number"
                     ref={pageNumberInput}
                     value={pageNumber}
-                    onChange={e => setPageNumber(e.target.value)}
-                  >
-                    {setDropdownNumbers()}
-                  </select>
+                    onChange={e => setPageNumber(parseInt(e.target.value, 10))}
+                    min={1}
+                    max={totalPages}
+                  />
                   <Button
                     dataElement="linkSubmitButton"
                     label={t('action.link')}
                     onClick={addPageLink}
+                    disabled={pageNumber < 0 || pageNumber > totalPages}
                   />
                 </div>
               </form>

--- a/src/components/LinkModal/LinkModal.js
+++ b/src/components/LinkModal/LinkModal.js
@@ -261,7 +261,7 @@ const LinkModal = () => {
                     dataElement="linkSubmitButton"
                     label={t('action.link')}
                     onClick={addPageLink}
-                    disabled={pageNumber < 0 || pageNumber > totalPages}
+                    disabled={pageNumber < 1 || pageNumber > totalPages}
                   />
                 </div>
               </form>

--- a/src/components/LinkModal/LinkModal.scss
+++ b/src/components/LinkModal/LinkModal.scss
@@ -184,6 +184,12 @@
       &:hover {
         background: var(--primary-button-hover);
       }
+
+      &.disabled {
+        background: var(--gray-6);
+        border-color: var(--gray-6);
+        cursor: not-allowed;
+      }
     }
   }
 }

--- a/src/components/LinkModal/LinkModal.scss
+++ b/src/components/LinkModal/LinkModal.scss
@@ -144,21 +144,14 @@
       }
     }
 
-    select {
-      margin-top: 8px;
-      width: 100px;
-      height: 30px;
-      border-radius: 5px;
-      border: 1px solid #e0e0e0;
+    input::-webkit-outer-spin-button,
+    input::-webkit-inner-spin-button {
+      -webkit-appearance: none;
+      margin: 0;
+    }
 
-      &:focus {
-        outline: none;
-        border: 1px solid var(--focus-border);
-      }
-
-      &::placeholder {
-        color: var(--placeholder-text);
-      }
+    input[type=number] {
+      -moz-appearance: textfield;
     }
 
     form {


### PR DESCRIPTION
The link modal creates a dropdown with an option for every page number
so for large documents (thousands of pages) this can take quite a while
to render.

This change updates the behavior so that you can type the page number
instead and the link button is disabled if the page is out of bounds.