### PR TITLE
[6.3] [Bugfix] Fixed issue where thumbnail panel was the wrong size after full screen

### DIFF
--- a/src/components/ThumbnailsPanel/ThumbnailsPanel.js
+++ b/src/components/ThumbnailsPanel/ThumbnailsPanel.js
@@ -84,10 +84,12 @@ class ThumbnailsPanel extends React.PureComponent {
   }
 
   onWindowResize = () => {
-    this.setState({
-      height: this.containerRef.current.clientHeight,
-      width: this.containerRef.current.clientWidth,
-    });
+    if (this.containerRef && this.containerRef.current) {
+      this.setState({
+        height: this.containerRef.current.clientHeight,
+        width: this.containerRef.current.clientWidth,
+      });
+    }
   }
 
   onBeginRendering = () => {

--- a/src/components/ThumbnailsPanel/ThumbnailsPanel.js
+++ b/src/components/ThumbnailsPanel/ThumbnailsPanel.js
@@ -44,6 +44,7 @@ class ThumbnailsPanel extends React.PureComponent {
     this.pendingThumbs = [];
     this.thumbs = [];
     this.listRef = React.createRef();
+    this.containerRef = React.createRef();
     this.afterMovePageNumber = null;
     this.isDraggingGroup = false;
     this.state = {
@@ -67,6 +68,7 @@ class ThumbnailsPanel extends React.PureComponent {
     core.addEventListener('pageNumberUpdated', this.onPageNumberUpdated);
     core.addEventListener('pageComplete', this.onPageComplete);
     core.addEventListener('annotationHidden', this.onAnnotationChanged);
+    window.addEventListener('resize', this.onWindowResize);
   }
 
   componentWillUnmount() {
@@ -78,6 +80,14 @@ class ThumbnailsPanel extends React.PureComponent {
     core.removeEventListener('pageNumberUpdated', this.onPageNumberUpdated);
     core.removeEventListener('pageComplete', this.onPageComplete);
     core.removeEventListener('annotationHidden', this.onAnnotationChanged);
+    window.removeEventListener('resize', this.onWindowResize);
+  }
+
+  onWindowResize = () => {
+    this.setState({
+      height: this.containerRef.current.clientHeight,
+      width: this.containerRef.current.clientWidth,
+    });
   }
 
   onBeginRendering = () => {
@@ -494,6 +504,7 @@ class ThumbnailsPanel extends React.PureComponent {
         style={{ display }}
         data-element="thumbnailsPanel"
         onDrop={this.onDrop}
+        ref={this.containerRef}
       >
         <Measure bounds onResize={this.onPanelResize}>
           {({ measureRef }) => (


### PR DESCRIPTION
The issue occurs when you load a document with enough pages to get a scroll bar in the page thumbnails panel, open the page thumbnails panel, full-screen WebViewer, and then exit full-screen. The inner thumbnail panel will be slightly longer than expected and the bottom of the panel will be offscreen. The update of the size is handled by the `Measure` component, but it will not trigger `onResize` since the panel did not resize when exiting full-screen.

This PR makes the component listen to the window resize event and updates the size using the container size which will be correct when exiting full-screen.