### PR TITLE
Select print annotations by default

### DIFF
--- a/src/components/PrintModal/PrintModal.js
+++ b/src/components/PrintModal/PrintModal.js
@@ -571,6 +571,7 @@ class PrintModal extends React.PureComponent {
                   type="checkbox"
                   label={t('option.print.includeAnnotations')}
                   disabled={isPrinting}
+                  defaultChecked
                 />
               </form>
             </div>


### PR DESCRIPTION
Fixes:
https://trello.com/c/apaiD3Y8/1195-printing-with-legacy-ui-doesnt-check-the-include-annotations-box-by-default