### PR TITLE
[Bugfix] Fixed UI crash due to undefined icon

### DIFF
--- a/src/constants/map.js
+++ b/src/constants/map.js
@@ -458,4 +458,4 @@ export const register = (tool, annotationConstructor, customAnnotCheckFunc) => {
 
 // we return an empty object here to prevent some components from accessing undefined
 // if the map doesn't have a key for some annotations
-export const getDataWithKey = key => map[key] || {};
+export const getDataWithKey = key => map[key] || { icon: 'icon - tool - pen and shape - phone - line' };


### PR DESCRIPTION
When an annotation has no associated icon, opening the NotesPanel crashes the UI. This PR gives it a default.