### PR TITLE
fix(Button): label should have disabled text color when the button is disabled

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -82,7 +82,7 @@ const Button = props => {
     >
       {isGlyph && <Icon glyph={imgToShow} color={color} />}
       {imgToShow && !isGlyph && <img src={imgToShow} />}
-      {label && label}
+      {label && <span>{t(label)}</span>}
     </button>
   );
 

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -41,6 +41,9 @@
     .Icon {
       color: var(--disabled-icon);
     }
+    span {
+      color: var(--disabled-icon);
+    }
     cursor: default;
   }
 }


### PR DESCRIPTION
To verify:

find a `Button` component that uses the `label` prop. Call `instance.updateElement(buttonDataElement, { disabled: true });`. Check that the text color is correct.