### PR TITLE
Added new API to set date format of printed notes

### DIFF
--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -102,6 +102,7 @@ import setLayoutMode from './setLayoutMode';
 import setMaxZoomLevel from './setMaxZoomLevel';
 import setMinZoomLevel from './setMinZoomLevel';
 import setNoteDateFormat from './setNoteDateFormat';
+import setPrintedNoteDateFormat from './setPrintedNoteDateFormat';
 import setNotesPanelSort from './setNotesPanelSort';
 import setPageLabels from './setPageLabels';
 import setPrintQuality from './setPrintQuality';
@@ -195,6 +196,7 @@ export default store => {
     setMaxZoomLevel: setMaxZoomLevel(store),
     setMinZoomLevel: setMinZoomLevel(store),
     setNoteDateFormat: setNoteDateFormat(store),
+    setPrintedNoteDateFormat: setPrintedNoteDateFormat(store),
     setMeasurementUnits: setMeasurementUnits(store),
     setPageLabels: setPageLabels(store),
     setPrintQuality: setPrintQuality(store),

--- a/src/apis/setPrintedNoteDateFormat.js
+++ b/src/apis/setPrintedNoteDateFormat.js
@@ -1,0 +1,16 @@
+/**
+ * Sets the format for displaying the date when a note is printed. A list of formats can be found {@link https://github.com/iamkun/dayjs/blob/master/docs/en/API-reference.md#format-formatstringwithtokens-string dayjs API}.
+ * @method WebViewerInstance#setPrintedNoteDateFormat
+ * @param {string} format The format of date to display
+ * @example
+WebViewer(...)
+  .then(function(instance) {
+    instance.setPrintedNoteDateFormat('DD.MM.YYYY HH:MM');
+  });
+ */
+
+import actions from 'actions';
+
+export default store => noteDateFormat => {
+  store.dispatch(actions.setPrintedNoteDateFormat(noteDateFormat));
+};

--- a/src/components/PrintModal/PrintModal.js
+++ b/src/components/PrintModal/PrintModal.js
@@ -36,7 +36,8 @@ class PrintModal extends React.PureComponent {
     sortStrategy: PropTypes.string.isRequired,
     colorMap: PropTypes.object.isRequired,
     layoutMode: PropTypes.string.isRequired,
-    isApplyWatermarkDisabled: PropTypes.bool
+    isApplyWatermarkDisabled: PropTypes.bool,
+    printedNoteDateFormat: PropTypes.string,
   };
 
   constructor() {
@@ -162,7 +163,8 @@ class PrintModal extends React.PureComponent {
       this.state.includeAnnotations,
       this.props.printQuality,
       this.props.sortStrategy,
-      this.props.colorMap
+      this.props.colorMap,
+      this.props.printedNoteDateFormat,
     );
     createPages.forEach(async pagePromise => {
       await pagePromise;
@@ -383,7 +385,8 @@ const mapStateToProps = state => ({
   pageLabels: selectors.getPageLabels(state),
   sortStrategy: selectors.getSortStrategy(state),
   colorMap: selectors.getColorMap(state),
-  layoutMode: selectors.getDisplayMode(state)
+  layoutMode: selectors.getDisplayMode(state),
+  printedNoteDateFormat: selectors.getPrintedNoteDateFormat(state),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/helpers/print.js
+++ b/src/helpers/print.js
@@ -91,7 +91,7 @@ const printPdf = () =>
       });
   });
 
-export const creatingPages = (pagesToPrint, includeComments, includeAnnot, printQualty, sortStrategy, clrMap) => {
+export const creatingPages = (pagesToPrint, includeComments, includeAnnot, printQualty, sortStrategy, clrMap, dateFormat) => {
   const createdPages = [];
   pendingCanvases = [];
   includeAnnotations = includeAnnot;
@@ -104,7 +104,7 @@ export const creatingPages = (pagesToPrint, includeComments, includeAnnot, print
 
     if (includeComments && printableAnnotations.length) {
       const sortedNotes = getSortStrategies()[sortStrategy].getSortedNotes(printableAnnotations);
-      createdPages.push(creatingNotesPage(sortedNotes, pageNumber));
+      createdPages.push(creatingNotesPage(sortedNotes, pageNumber, dateFormat));
     }
   });
 
@@ -182,7 +182,7 @@ const creatingImage = (pageNumber, printableAnnotations) =>
     pendingCanvases.push(id);
   });
 
-const creatingNotesPage = (annotations, pageNumber) =>
+const creatingNotesPage = (annotations, pageNumber, dateFormat) =>
   new Promise(resolve => {
     const container = document.createElement('div');
     container.className = 'page__container';
@@ -193,7 +193,7 @@ const creatingNotesPage = (annotations, pageNumber) =>
 
     container.appendChild(header);
     annotations.forEach(annotation => {
-      const note = getNote(annotation);
+      const note = getNote(annotation, dateFormat);
 
       container.appendChild(note);
     });
@@ -270,7 +270,7 @@ const getDocumentRotation = pageIndex => {
   return (completeRotation - viewerRotation + 4) % 4;
 };
 
-const getNote = annotation => {
+const getNote = (annotation, dateFormat) => {
   const note = document.createElement('div');
   note.className = 'note';
 
@@ -291,7 +291,7 @@ const getNote = annotation => {
   annotation.getReplies().forEach(reply => {
     const noteReply = document.createElement('div');
     noteReply.className = 'note__reply';
-    noteReply.appendChild(getNoteInfo(reply));
+    noteReply.appendChild(getNoteInfo(reply, dateFormat));
     noteReply.appendChild(getNoteContent(reply));
 
     note.appendChild(noteReply);
@@ -329,14 +329,14 @@ const getNoteIcon = annotation => {
   return noteIcon;
 };
 
-const getNoteInfo = annotation => {
+const getNoteInfo = (annotation, dateFormat) => {
   const info = document.createElement('div');
 
   info.className = 'note__info';
   info.innerHTML = `
     Author: ${core.getDisplayAuthor(annotation) || ''} &nbsp;&nbsp;
     Subject: ${annotation.Subject} &nbsp;&nbsp;
-    Date: ${dayjs(annotation.DateCreated).format('D/MM/YYYY h:mm:ss A')}
+    Date: ${dayjs(annotation.DateCreated).format(dateFormat || 'D/MM/YYYY h:mm:ss A')}
   `;
   return info;
 };

--- a/src/redux/actions/exposedActions.js
+++ b/src/redux/actions/exposedActions.js
@@ -368,6 +368,10 @@ export const setNoteDateFormat = noteDateFormat => ({
   type: 'SET_NOTE_DATE_FORMAT',
   payload: { noteDateFormat },
 });
+export const setPrintedNoteDateFormat = noteDateFormat => ({
+  type: 'SET_PRINTED_NOTE_DATE_FORMAT',
+  payload: { noteDateFormat },
+});
 export const setCustomPanel = newPanel => ({
   type: 'SET_CUSTOM_PANEL',
   payload: { newPanel },

--- a/src/redux/initialState.js
+++ b/src/redux/initialState.js
@@ -434,6 +434,7 @@ export default {
     pageLabels: [],
     selectedThumbnailPageIndexes: [],
     noteDateFormat: 'MMM D, h:mma',
+    printedNoteDateFormat: 'D/MM/YYYY h:mm:ss A',
     colorMap: copyMapWithDataProperties('currentPalette', 'iconColor'),
     warning: {},
     customNoteFilter: null,

--- a/src/redux/reducers/viewerReducer.js
+++ b/src/redux/reducers/viewerReducer.js
@@ -180,6 +180,8 @@ export default initialState => (state = initialState, action) => {
       return { ...state, sortStrategy: payload.sortStrategy };
     case 'SET_NOTE_DATE_FORMAT':
       return { ...state, noteDateFormat: payload.noteDateFormat };
+    case 'SET_PRINTED_NOTE_DATE_FORMAT':
+      return { ...state, printedNoteDateFormat: payload.noteDateFormat };
     case 'SET_FULL_SCREEN':
       return { ...state, isFullScreen: payload.isFullScreen };
     case 'SET_HEADER_ITEMS':

--- a/src/redux/selectors/exposedSelectors.js
+++ b/src/redux/selectors/exposedSelectors.js
@@ -156,6 +156,8 @@ export const getRotation = state => state.viewer.rotation;
 
 export const getNoteDateFormat = state => state.viewer.noteDateFormat;
 
+export const getPrintedNoteDateFormat = state => state.viewer.printedNoteDateFormat;
+
 export const isFullScreen = state => state.viewer.isFullScreen;
 
 export const doesDocumentAutoLoad = state => state.viewer.doesAutoLoad;


### PR DESCRIPTION
Added a new API `setPrintedNoteDateFormat` to set the format of dates displayed on the notes page when printing.