### PR TITLE
bugfix/add page-break-inside: avoid to .note CSS class

### DIFF
--- a/src/components/PrintHandler/PrintHandler.scss
+++ b/src/components/PrintHandler/PrintHandler.scss
@@ -44,7 +44,7 @@
 
     .page__container {
       box-sizing: border-box;
-      display: flex;
+      display: table;
       flex-direction: column;
       padding: 10px;
       min-height: 100%;
@@ -60,12 +60,13 @@
       }
 
       .note {
-        display: flex;
+        display: table;
         flex-direction: column;
         padding: 0.6rem;
         border: 0.1rem lightgray solid;
         border-radius: 0.4rem;
         margin-bottom: 0.5rem;
+        page-break-inside: avoid;
 
         .note__info {
           font-size: 1.3rem;


### PR DESCRIPTION
## Preamble

I made this change for a client who needed the comments not to be rendered across a page break, and this is the solution I suggested as a start.

![image](https://user-images.githubusercontent.com/16601729/90670432-0897c000-e208-11ea-9d0e-8b12f7e7d4b7.png)

Left is before, right is after.

Haven't had time to test the greater implications of `display: flex` to `display: table` (`page-break-inside: avoid` doesn't play nicely with `display: flex`), so I figured I'd put this up as a Draft PR, and if it becomes an issue that needs to be fixed in the future, someone on the WebViewer team could take a closer look and see if there's more robust solution.