### PR TITLE
[Bugfix] Fixed issue where page nav was off screen in IE11

### DIFF
--- a/src/components/DocumentContainer/DocumentContainer.scss
+++ b/src/components/DocumentContainer/DocumentContainer.scss
@@ -41,6 +41,10 @@
       * {
         pointer-events: all;
       }
+
+      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+        top: 0;
+      }
     }
   }
 

--- a/src/components/PageNavOverlay/PageNavOverlay.scss
+++ b/src/components/PageNavOverlay/PageNavOverlay.scss
@@ -25,6 +25,10 @@
   z-index: 0;
   bottom: 20px;
 
+  @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+    left: auto;
+    bottom: 50px;
+  }
 
   .side-arrow-container {
     @include button-reset;


### PR DESCRIPTION
This PR adds IE-specific CSS to position the page nav properly.

![image](https://user-images.githubusercontent.com/25498512/90695584-9935c680-e22f-11ea-81af-7b231d669365.png)
