### PR TITLE
[Bugfix] Fix random "annotationChanged" event firing with measurement tool

### DIFF
--- a/src/components/MeasurementOverlay/LineMeasurementInput.js
+++ b/src/components/MeasurementOverlay/LineMeasurementInput.js
@@ -53,14 +53,11 @@ function LineMeasurementInput(props) {
   };
 
   const ensureLineIsWithinBounds = useCallback(lengthInPts => {
-    const maxLengthInPts = getMaxLineLengthInPts();
-
-    if (lengthInPts > maxLengthInPts) {
-      annotation.setLineLength(maxLengthInPts);
-    } else {
-      annotation.setLineLength(lengthInPts);
+    if (annotation.getLineLength() !== lengthInPts) {
+      const maxLengthInPts = getMaxLineLengthInPts();
+      annotation.setLineLength(Math.min(maxLengthInPts, lengthInPts));
+      forceLineRedraw();
     }
-    forceLineRedraw();
   }, [annotation, forceLineRedraw, getMaxLineLengthInPts]);
 
   const forceLineRedraw = useCallback(() => {


### PR DESCRIPTION
Currently `annotationChanged` get fired

1. Before the "add" event when adding new line dimension
2. Selecting and deselecting line dimension will trigger the `annotationChanged` event

This is because we are always calling "setLineLength" which fires `annotationChanged`. Also when creating new annotation, the `foreLineRedraw` function is being called which trigger a "modify" `annotationChanged` before the "add" event get fired