### PR TITLE
[Draft] Highlight note button

### DIFF
--- a/src/components/ActionButton/ActionButton.js
+++ b/src/components/ActionButton/ActionButton.js
@@ -2,13 +2,15 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 
 import Button from 'components/Button';
+import selectors from 'selectors';
 
-const mapStateToProps = (state, { isNotClickableSelector, className }) => ({
+const mapStateToProps = (state, { isNotClickableSelector, className, element }) => ({
   className: classNames({
     ActionButton: true,
     [className]: !!className,
   }),
   disabled: isNotClickableSelector && isNotClickableSelector(state),
+  isActive: selectors.isElementOpen(state, element),
 });
 
 const mapDispatchToProps = (dispatch, ownProps) => ({

--- a/src/redux/initialState.js
+++ b/src/redux/initialState.js
@@ -60,6 +60,7 @@ export default {
           dataElement: 'toggleNotesButton',
           img: 'icon-header-chat-line',
           title: 'component.notesPanel',
+          element: 'notesPanel',
           onClick: dispatch => {
             dispatch(actions.toggleElement('notesPanel'));
             // Trigger with a delay so we ensure the panel is open before we compute correct coordinates of annotation


### PR DESCRIPTION
This is a PR that highlight the note button when the note panel is opened. This draft pull request is to show someone what we are doing.

This is not intended to be merged in (another PR will add this change to version 7.1 or 7.2 of the UI)