### PR TITLE
fixed PDFTron intialization bug when no full api is used

### DIFF
--- a/src/helpers/eventHandler.js
+++ b/src/helpers/eventHandler.js
@@ -75,7 +75,7 @@ export default store => {
       core.getTool('AnnotationCreateFileAttachment').addEventListener('annotationAdded', onFileAttachmentAnnotationAdded);
       core.getTool(ToolNames.FORM_FILL_CROSS).addEventListener('annotationAdded', onCrossStampAnnotationAdded);
       core.getTool(ToolNames.FORM_FILL_CHECKMARK).addEventListener('annotationAdded', onCheckStampAnnotationAdded);
-      hotkeysManager.initialize(store);
+
       document.addEventListener('fullscreenchange', onFullScreenChange);
       document.addEventListener('mozfullscreenchange', onFullScreenChange);
       document.addEventListener('webkitfullscreenchange', onFullScreenChange);

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,7 @@ import getHashParams from 'helpers/getHashParams';
 import defineWebViewerInstanceUIAPIs from 'src/apis';
 
 import './index.scss';
+import hotkeysManager from "helpers/hotkeysManager";
 
 const middleware = [thunk];
 
@@ -154,25 +155,28 @@ if (window.CanvasRenderingContext2D) {
 
   const documentViewer = new window.Core.DocumentViewer();
   window.documentViewer = documentViewer;
+  hotkeysManager.initialize(store);
+
 
   defineWebViewerInstanceUIAPIs(store);
+
 
   fullAPIReady.then(() => loadConfig()).then(() => {
     if (preloadWorker) {
       initTransports();
     }
 
-    const { addEventHandlers, removeEventHandlers } = eventHandler(store);
-
     if (getHashParams('enableViewStateAnnotations', false)) {
       const tool = documentViewer.getTool(window.Core.Tools.ToolNames.STICKY);
       tool?.setSaveViewState(true);
     }
 
+    const { addEventHandlers, removeEventHandlers } = eventHandler(store);
     setupDocViewer();
     setupI18n(state);
     setUserPermission(state);
     setAutoSwitch();
+
     addEventHandlers();
     setDefaultDisabledElements(store);
     setupLoadAnnotationsFromServer(store);


### PR DESCRIPTION
We use XOD files only and when we upgraded to 8.2 we have got following error in the consol
![obrazek-20211202-123404](https://user-images.githubusercontent.com/1236966/144429139-4b7cb50a-cf6e-4e68-a1a7-97444c23056a.png)
e.

This code change has fixed the issue.