### PR TITLE
added action to select page form, so iOS handles it correctly

### DIFF
--- a/src/components/PageNavOverlay/PageNavOverlay.js
+++ b/src/components/PageNavOverlay/PageNavOverlay.js
@@ -148,7 +148,7 @@ class PageNavOverlay extends React.PureComponent {
           disabled={window.documentViewer.getCurrentPage() === 1}
         />
         <div className="formContainer" onClick={this.onClick}>
-          <form onSubmit={this.onSubmit} onBlur={this.onBlur} onFocus={this.onFocus}>
+          <form action='' onSubmit={this.onSubmit} onBlur={this.onBlur} onFocus={this.onFocus}>
             <input
               ref={this.textInput}
               type="text"


### PR DESCRIPTION
This is needed, with the action attribute the keyboard shows "Go" instead of "Return" on iOS (without it, it does not have to call onSubmit event.)