### PR TITLE
print page limit feature

### DIFF
--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -124,6 +124,7 @@ import setPrintedNoteDateFormat from './setPrintedNoteDateFormat';
 import setNotesPanelSort from './setNotesPanelSort';
 import setPageLabels from './setPageLabels';
 import setPrintQuality from './setPrintQuality';
+import setPrintPageLimit from './setPrintPageLimit';
 import setDefaultPrintOptions from './setDefaultPrintOptions';
 import setSelectedTab from './setSelectedTab';
 import setSideWindowVisibility from './setSideWindowVisibility';
@@ -274,6 +275,7 @@ export default store => {
     setMeasurementUnits: setMeasurementUnits(store),
     setPageLabels: setPageLabels(store),
     setPrintQuality: setPrintQuality(store),
+    setPrintPageLimit: setPrintPageLimit(store),
     setDefaultPrintOptions: setDefaultPrintOptions(store),
     setNotesPanelSortStrategy: setNotesPanelSortStrategy(store),
     setSwipeOrientation,

--- a/src/apis/setPrintPageLimit.js
+++ b/src/apis/setPrintPageLimit.js
@@ -1,0 +1,19 @@
+/**
+ * Sets the print page limit. This is a limit how many pages will be rendered at once. The viewer's default limit is 0 (unlimited).
+ * @method UI.setPrintPageLimit
+ * @param {number} limit The page rendering limit of the document to print. Must be a positive number or zero (unlimited).
+ * @example
+ WebViewer(...)
+ .then(function(instance) {
+    instance.UI.setPrintPageLimit(100);
+  });
+ */
+
+import actions from 'actions';
+
+export default store => limit => {
+    if (limit < 0) {
+        throw Error('Value must be a positive number or zero (unlimited)');
+    }
+    store.dispatch(actions.setPrintPageLimit(limit));
+};

--- a/src/redux/actions/internalActions.js
+++ b/src/redux/actions/internalActions.js
@@ -334,6 +334,10 @@ export const setPrintQuality = quality => ({
   type: 'SET_PRINT_QUALITY',
   payload: { quality },
 });
+export const setPrintPageLimit = limit => ({
+  type: 'SET_PRINT_PAGE_LIMIT',
+  payload: { limit },
+});
 export const setDefaultPrintOptions = options => ({
   type: 'SET_DEFAULT_PRINT_OPTIONS',
   payload: { options },

--- a/src/redux/initialState.js
+++ b/src/redux/initialState.js
@@ -640,6 +640,7 @@ export default {
     bookmarks: {},
     layers: [],
     printQuality: 1,
+    printPageLimit: 0,
     passwordAttempts: -1,
     loadingProgress: 0,
   },

--- a/src/redux/reducers/documentReducer.js
+++ b/src/redux/reducers/documentReducer.js
@@ -34,6 +34,8 @@ export default initialState => (state = initialState, action) => {
       return { ...state, passwordAttempts: payload.attempt };
     case 'SET_PRINT_QUALITY':
       return { ...state, printQuality: payload.quality };
+    case 'SET_PRINT_PAGE_LIMIT':
+      return { ...state, printPageLimit: payload.limit }
     case 'SET_DEFAULT_PRINT_OPTIONS':
       return {...state, defaultPrintOptions: payload.options };
     case 'SET_LOADING_PROGRESS':

--- a/src/redux/selectors/exposedSelectors.js
+++ b/src/redux/selectors/exposedSelectors.js
@@ -330,6 +330,8 @@ export const getPasswordAttempts = state => state.document.passwordAttempts;
 
 export const getPrintQuality = state => state.document.printQuality;
 
+export const getPrintPageLimit = state => state.document.printPageLimit;
+
 export const getDefaultPrintOptions = state => state.document.defaultPrintOptions;
 
 export const getTotalPages = state => state.document.totalPages;


### PR DESCRIPTION
I have implemented print page limit feature to our fork. I am creating a pull request so if you are interested, you can merge this in your repository.

The problem with the print was that if you have a large 5000 pages document and you are trying to render all pages for print, the resources of a browser are not enough and the print fails. Now you can do this: 
`viewer.UI.setPrintPageLimit(100);`
which will render only 100 pages, then the browser print dialog is shown and after closing it it will render another 100 pages another browser print dialog and so on.