### PR TITLE
Add missing thumb rotate button (counterclockwise)

### DIFF
--- a/src/redux/initialState.js
+++ b/src/redux/initialState.js
@@ -583,6 +583,7 @@ export default {
     ],
     thumbnailControlMenu: [
       { dataElement: 'thumbRotateClockwise' },
+      { dataElement: 'thumbRotateCounterClockwise' },
       { dataElement: 'thumbDelete' },
     ],
     toolButtonObjects: {


### PR DESCRIPTION
The button for rotating counterclockwise is missing in the UI and can not be added later in runtime