### PR TITLE
fix issue #1101 where viewer crashes when ui is resized with disabled elements

### DIFF
--- a/src/redux/selectors/exposedSelectors.js
+++ b/src/redux/selectors/exposedSelectors.js
@@ -1294,7 +1294,7 @@ const hasPanelInItems = (items, panelType) => {
       }
     }
 
-    if (typeof item === 'object' && item.render === panelType) {
+    if (item && typeof item === 'object' && item.render === panelType) {
       return true;
     }
 


### PR DESCRIPTION
Add sanity check to prevent viewer from crashing.

Fixes https://github.com/ApryseSDK/webviewer-ui/issues/1101